### PR TITLE
fix: background palette

### DIFF
--- a/src/colors/editor/input.colors.ts
+++ b/src/colors/editor/input.colors.ts
@@ -1,13 +1,13 @@
 import { EditorColors } from '../../types/colors-types';
-import { background_200, background_300 } from '../palette/background.colors';
+import { background_400, background_500 } from '../palette/background.colors';
 import { blue_100, blue_800, blue_900 } from '../palette/blue.colors';
 import { gray_100, gray_400 } from '../palette/gray.colors';
 import { purple_400 } from '../palette/purple.colors';
 import { red_100, red_800, red_900 } from '../palette/red.colors';
 import { yellow_100, yellow_800, yellow_900 } from '../palette/yellow.colors';
 
-export const inputBackground: string = background_300;
-export const inputBorder: string = background_200;
+export const inputBackground: string = background_500;
+export const inputBorder: string = background_400;
 export const inputForeground: string = gray_100;
 
 const inputColors: EditorColors = {

--- a/src/colors/editor/menu.bar.colors.ts
+++ b/src/colors/editor/menu.bar.colors.ts
@@ -14,7 +14,7 @@ const menuBarColors: EditorColors = {
   },
   menubar: {
     selectionBackground: modalBackground,
-    selectionBorder: modalBorder,
+    selectionBorder: modalBackground,
     selectionForeground: gray_100
   }
 };

--- a/src/colors/editor/notification.colors.ts
+++ b/src/colors/editor/notification.colors.ts
@@ -1,4 +1,5 @@
 import { EditorColors } from '../../types/colors-types';
+import { background_300 } from '../palette/background.colors';
 import { gray_100, gray_200 } from '../palette/gray.colors';
 import { purple_300 } from '../palette/purple.colors';
 import { modalBackground, modalBorder } from './modal.colors';
@@ -9,7 +10,7 @@ const notificationColors: EditorColors = {
     border: modalBorder
   },
   notificationCenterHeader: {
-    background: modalBackground,
+    background: background_300,
     foreground: gray_200
   },
   notificationLink: {

--- a/src/colors/palette/background.colors.ts
+++ b/src/colors/palette/background.colors.ts
@@ -1,12 +1,12 @@
-export const background_100 = '#172B3A';
-export const background_200 = '#142736';
-export const background_300 = '#122431';
-export const background_400 = '#0F202D';
-export const background_500 = '#0D1D29';
+export const background_100 = '#2E4759';
+export const background_200 = '#243C4D';
+export const background_300 = '#1C3242';
+export const background_400 = '#152836';
+export const background_500 = '#0F202D';
 export const background_600 = '#0B1A25';
-export const background_700 = '#091621';
-export const background_800 = '#08141C';
-export const background_900 = '#061018';
+export const background_700 = '#08151F';
+export const background_800 = '#050F17';
+export const background_900 = '#020A0F';
 
 export default {
   background_100,


### PR DESCRIPTION
The background palette was fixed: the colors in the previous one are too similar, it was difficult to differentiate the elements in the UI

---
![legacy-palette](https://user-images.githubusercontent.com/16739011/55294104-422e1800-53d4-11e9-99ad-4868d4497a91.png)
![new-palette](https://user-images.githubusercontent.com/16739011/55294105-422e1800-53d4-11e9-96f0-7fb1e3a5f273.png)

![preview-old](https://user-images.githubusercontent.com/16739011/55294107-45c19f00-53d4-11e9-900f-784afc2e091e.png)
![preview-new](https://user-images.githubusercontent.com/16739011/55294106-45c19f00-53d4-11e9-9d79-a942eec9ffbc.png)


