### PR TITLE
fix: Make scrollbar semi-transparent

### DIFF
--- a/src/colors/editor/scrollbar.colors.ts
+++ b/src/colors/editor/scrollbar.colors.ts
@@ -1,5 +1,6 @@
 import { EditorColors } from '../../types/colors-types';
 import { background_700 } from '../palette/background.colors';
+import { opacity_40, opacity_50, opacity_60 } from '../palette/opacity';
 import { purple_600, purple_700 } from '../palette/purple.colors';
 
 const scrollbarColors: EditorColors = {
@@ -7,9 +8,9 @@ const scrollbarColors: EditorColors = {
     shadow: background_700
   },
   scrollbarSlider: {
-    activeBackground: purple_600,
-    background: purple_700,
-    hoverBackground: purple_600
+    activeBackground: `${purple_600}${opacity_60}`,
+    background: `${purple_700}${opacity_50}`,
+    hoverBackground: `${purple_600}${opacity_40}`
   }
 };
 


### PR DESCRIPTION
### Fixed

Make scrollbar semi-transparent: scrollbar markers are not visible when covered by the scrollbar

Fixes #17 