### PR TITLE
feat: Syntax consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Use defined colors for an element in all languages**: green for `strings` or orange for `numbers`. If you want to see an in-depth reference, please go to color reference in the README.
+
 ## [1.1.0] 2019-04-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -87,7 +87,59 @@ If you want support for another `language` / `library` / `framework`, please ope
 
 ## ✨ Color reference
 
-The syntax highlight palette was inspired by **Tailwind v1 colors**.
+### User interface
+
+| Usage             | Color       | Hex color                                                          |
+|-------------------|-------------|--------------------------------------------------------------------|
+| editor background | dark blue 5 | ![#0B1A25](https://placehold.it/15/0B1A25/000000?text=+) `#0B1A25` |
+| editor foreground | blue gray 0 | ![#ECEFF1](https://placehold.it/15/ECEFF1/000000?text=+) `#ECEFF1` |
+
+
+### Syntax hightlight
+
+The colors used for the syntax highlighting are from **Material Design**.
+
+#### Data types
+
+| Usage                          | Color              | Hex color                                                          |
+|--------------------------------|--------------------|--------------------------------------------------------------------|
+| number                         | orange 2           | ![#FFCC80](https://placehold.it/15/FFCC80/000000?text=+) `#FFCC80` |
+| string                         | green 2            | ![#A5D6A7](https://placehold.it/15/A5D6A7/000000?text=+) `#A5D6A7` |
+| constant (boolean, null)       | purple 2 or blue 2 | ![#B39DDB](https://placehold.it/15/B39DDB/000000?text=+) `#B39DDB` |
+| character                      | pink 1             | ![#F8BBD0](https://placehold.it/15/F8BBD0/000000?text=+) `#F8BBD0` |
+| escape character               | purple 2           | ![#B39DDB](https://placehold.it/15/B39DDB/000000?text=+) `#B39DDB` |
+| custom type (interface, class) | cyan 2             | ![#80DEEA](https://placehold.it/15/80DEEA/000000?text=+) `#80DEEA` |
+| other type                     | purple 2           | ![#B39DDB](https://placehold.it/15/B39DDB/000000?text=+) `#B39DDB` |
+
+#### Keywords
+
+| Usage   | Color    | Hex color                                                          |
+|---------|----------|--------------------------------------------------------------------|
+| keyword | purple 2 | ![#B39DDB](https://placehold.it/15/B39DDB/000000?text=+) `#B39DDB` |
+
+#### Variables, functions & classes
+
+| Usage           | Color    | Hex color                                                          |
+|-----------------|----------|--------------------------------------------------------------------|
+| variable        | pink 1   | ![#F8BBD0](https://placehold.it/15/F8BBD0/000000?text=+) `#F8BBD0` |
+| object property | indigo 2 | ![#9FA8DA](https://placehold.it/15/9FA8DA/000000?text=+) `#9FA8DA` |
+| function name   | blue 2   | ![#90CAF9](https://placehold.it/15/90CAF9/000000?text=+) `#90CAF9` |
+| class name      | blue 2   | ![#90CAF9](https://placehold.it/15/90CAF9/000000?text=+) `#90CAF9` |
+
+#### Invalid
+
+| Usage      | Color | Hex color                                                          |
+|------------|-------|--------------------------------------------------------------------|
+| deprecated | red 2 | ![#EF9A9A](https://placehold.it/15/EF9A9A/000000?text=+) `#EF9A9A` |
+| illegal    | red 2 | ![#EF9A9A](https://placehold.it/15/EF9A9A/000000?text=+) `#EF9A9A` |
+
+#### Other
+
+| Usage       | Color       | Hex color                                                          |
+|-------------|-------------|--------------------------------------------------------------------|
+| module name | blue 2      | ![#90CAF9](https://placehold.it/15/90CAF9/000000?text=+) `#90CAF9` |
+| text        | blue gray 1 | ![#ECEFF1](https://placehold.it/15/ECEFF1/000000?text=+) `#ECEFF1` |
+| comment     | blue gray 3 | ![#90A4AE](https://placehold.it/15/90A4AE/000000?text=+) `#90A4AE` |
 
 ## 🌌 FAQ
 *Frequently Asked Questions.*

--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ I love Ayu icons. You need to install the `Ayu theme`
 #### What are the recommended settings to use with Bracket Pair Colorizer?
 
 ```json
-"bracket-pair-colorizer-2.colors": ["#ecc94b", "#4fd1c5", "#f687b3"],
-"bracket-pair-colorizer-2.forceUniqueOpeningColor": true,
-"bracket-pair-colorizer-2.forceIterationColorCycle": true,
+"bracket-pair-colorizer-2.colors": ["#9575CD", "#F06292", "#4DD0E1"],
+"bracket-pair-colorizer-2.forceUniqueOpeningColor": false,
+"bracket-pair-colorizer-2.forceIterationColorCycle": false,
 "bracket-pair-colorizer-2.highlightActiveScope": true,
 "editor.matchBrackets": false,
 "bracket-pair-colorizer-2.activeScopeCSS": ["opacity: 0"],

--- a/demos/html/html.demo.html
+++ b/demos/html/html.demo.html
@@ -128,3 +128,10 @@
     <td>second row, second column</td>
   </tr>
 </table>
+
+<!-- Deprecated tags -->
+<applet></applet>
+<center></center>
+<dir></dir>
+<font></font>
+<strike> </strike>

--- a/docs/syntax-highlight.md
+++ b/docs/syntax-highlight.md
@@ -1,0 +1,95 @@
+# Syntax highlight
+
+## Language Grammars
+Language grammars are used to assign names to document elements such as keywords, comments, strings or similar. The purpose of this is to allow styling (syntax highlighting) and to make the text editor “smart” about which context the caret is in.
+
+The language grammar is used only to parse the document and assign names to subsets of this document. Then scope selectors can be used for styling, preferences and deciding how keys and tab triggers should expand.
+
+### Scope name
+This should be a unique name for the grammar, following the convention of being a dot-separated name where each new (left-most) part specializes the name. Normally it would be a two-part name where the first is either text or source and the second is the name of the language or document type. But if you are specializing an existing type, you probably want to derive the name from the type you are specializing.
+
+### Naming Conventions
+
+You can assign basically any name you wish to any part of the document that you can markup with the grammar system and then use that name in scope selectors.
+
+**There are however conventions so that one theme can target as many languages as possible, without having dozens of rules specific to each language and also so that functionality can be re-used across languages**.
+
+Here is a list of the 11 root groups which are currently in use with some explanation about their intended purpose. This is presented as a hierarchical list but the actual scope name is obtained by joining the name from each level with a dot. For example double-slash is comment.line.double-slash.
+
+*   `comment` — for comments.
+    *   `line` — line comments, we specialize further so that the type of comment start character(s) can be extracted from the scope.
+        *   `double-slash` — `// comment`
+        *   `double-dash` — `-- comment`
+        *   `number-sign` — `# comment`
+        *   `percentage` — `% comment`
+        *   _character_ — other types of line comments.
+    *   `block` — multi-line comments like `/* … */` and `<!-- … -->`.
+        *   `documentation` — embedded documentation.
+*   `constant` — various forms of constants.
+    
+    *   `numeric` — those which represent numbers, e.g. `42`, `1.3f`, `0x4AB1U`.
+    *   `character` — those which represent characters, e.g. `&lt;`, `\e`, `\031`.
+        *   `escape` — escape sequences like `\e` would be `constant.character.escape`.
+    *   `language` — constants (generally) provided by the language which are “special” like `true`, `false`, `nil`, `YES`, `NO`, etc.
+    *   `other` — other constants, e.g. colors in CSS.
+*   `entity` — an entity refers to a larger part of the document, for example a chapter, class, function, or tag. We do not scope the entire entity as `entity.*` (we use `meta.*` for that). But we do use `entity.*` for the “placeholders” in the larger entity, e.g. if the entity is a chapter, we would use `entity.name.section` for the chapter title.
+    
+    *   `name` — we are naming the larger entity.
+        *   `function` — the name of a function.
+        *   `type` — the name of a type declaration or class.
+        *   `tag` — a tag name.
+        *   `section` — the name is the name of a section/heading.
+    *   `other` — other entities.
+        *   `inherited-class` — the superclass/baseclass name.
+        *   `attribute-name` — the name of an attribute (mainly in tags).
+*   `invalid` — stuff which is “invalid”.
+    *   `illegal` — illegal, e.g. an ampersand or lower-than character in HTML (which is not part of an entity/tag).
+    *   `deprecated` — for deprecated stuff e.g. using an API function which is deprecated or using styling with strict HTML.
+*   `keyword` — keywords (when these do not fall into the other groups).
+    *   `control` — mainly related to flow control like `continue`, `while`, `return`, etc.
+    *   `operator` — operators can either be textual (e.g. `or`) or be characters.
+    *   `other` — other keywords.
+*   `markup` — this is for markup languages and generally applies to larger subsets of the text.
+    *   `underline` — underlined text.
+        *   `link` — this is for links, as a convenience this is derived from `markup.underline` so that if there is no theme rule which specifically targets `markup.underline.link` then it will inherit the underline style.
+    *   `bold` — bold text (text which is strong and similar should preferably be derived from this name).
+    *   `heading` — a section header. Optionally provide the heading level as the next element, for example `markup.heading.2.html` for `<h2>…</h2>` in HTML.
+    *   `italic` — italic text (text which is emphasized and similar should preferably be derived from this name).
+    *   `list` — list items.
+        *   `numbered` — numbered list items.
+        *   `unnumbered` — unnumbered list items.
+    *   `quote` — quoted (sometimes block quoted) text.
+    *   `raw` — text which is verbatim, e.g. code listings. Normally spell checking is disabled for `markup.raw`.
+    *   `other` — other markup constructs.
+*   `meta` — the meta scope is generally used to markup larger parts of the document. For example the entire line which declares a function would be `meta.function` and the subsets would be `storage.type`, `entity.name.function`, `variable.parameter` etc. and only the latter would be styled. Sometimes the meta part of the scope will be used only to limit the more general element that is styled, most of the time meta scopes are however used in scope selectors for activation of bundle items. For example in Objective-C there is a meta scope for the interface declaration of a class and the implementation, allowing the same tab-triggers to expand differently, depending on context.
+    
+*   `storage` — things relating to “storage”.
+    *   `type` — the type of something, `class`, `function`, `int`, `var`, etc.
+    *   `modifier` — a storage modifier like `static`, `final`, `abstract`, etc.
+*   `string` — strings.
+    *   `quoted` — quoted strings.
+        *   `single` — single quoted strings: `'foo'`.
+        *   `double` — double quoted strings: `"foo"`.
+        *   `triple` — triple quoted strings: `"""Python"""`.
+        *   `other` — other types of quoting: `$'shell'`, `%s{...}`.
+    *   `unquoted` — for things like here-docs and here-strings.
+    *   `interpolated` — strings which are “evaluated”: `` `date` ``, `$(pwd)`.
+    *   `regexp` — regular expressions: `/(\w+)/`.
+    *   `other` — other types of strings (should rarely be used).
+*   `support` — things provided by a framework or library should be below `support`.
+    *   `function` — functions provided by the framework/library. For example `NSLog` in Objective-C is `support.function`.
+    *   `class` — when the framework/library provides classes.
+    *   `type` — types provided by the framework/library, this is probably only used for languages derived from C, which has `typedef` (and `struct`). Most other languages would introduce new types as classes.
+    *   `constant` — constants (magic values) provided by the framework/library.
+    *   `variable` — variables provided by the framework/library. For example `NSApp` in AppKit.
+    *   `other` — the above should be exhaustive, but for everything else use `support.other`.
+*   `variable` — variables. Not all languages allow easy identification (and thus markup) of these.
+    *   `parameter` — when the variable is declared as the parameter.
+    *   `language` — reserved language variables like `this`, `super`, `self`, etc.
+    *   `other` — other variables, like `$some_variables`.
+
+## Resources
+- [Syntax Highlight Guide](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide)
+- [Writing a TextMate Grammar: Some Lessons Learned](https://www.apeth.com/nonblog/stories/textmatebundle.html)
+- [TextMate Language Grammars](https://macromates.com/manual/en/language_grammars)
+- [Introduction to scopes](https://macromates.com/blog/2005/introduction-to-scopes/)

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -42,15 +42,15 @@ const commonColors: SyntaxColors = (tokens) => {
     {
       name: 'Variable',
       scope: 'variable',
-      settings: tokens.variable
+      settings: tokens.variable.default
     },
     {
-      name: 'Constant',
-      scope: 'variable.other.constant',
-      settings: tokens.constant
+      name: 'Other variable',
+      scope: 'variable.other',
+      settings: tokens.variable.other
     },
     {
-      name: 'Language variable',
+      name: 'Language variable (this, super, self)',
       scope: 'variable.language',
       settings: tokens.type.constant.language
     },
@@ -64,14 +64,9 @@ const commonColors: SyntaxColors = (tokens) => {
      * Objects
      */
     {
-      name: 'Object variable',
-      scope: 'variable.other.object',
-      settings: tokens.variable
-    },
-    {
-      name: 'Variable property value',
+      name: 'Access to object property',
       scope: 'variable.other.property',
-      settings: tokens.variable
+      settings: tokens.variable.default
     },
     {
       name: 'Object property',

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -148,6 +148,11 @@ const commonColors: SyntaxColors = (tokens) => {
       settings: tokens.type.languageConstant.default
     },
     {
+      name: 'Other constant',
+      scope: 'constant.other',
+      settings: tokens.type.other
+    },
+    {
       name: 'Custom type',
       scope: 'entity.name.type',
       settings: tokens.type.custom

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -176,17 +176,26 @@ const commonColors: SyntaxColors = (tokens) => {
     },
 
     /**
-     * Other
+     * Comments
      */
     {
       name: 'Comment',
       scope: 'comment',
       settings: tokens.comment
     },
+
+    /**
+     * Invalid
+     */
     {
       name: 'Invalid',
-      scope: ['invalid', 'invalid.illegal'],
+      scope: 'invalid.illegal',
       settings: tokens.invalid.illegal
+    },
+    {
+      name: 'Deprecated',
+      scope: 'invalid.deprecated',
+      settings: tokens.invalid.deprecated
     },
 
     /**

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -11,6 +11,27 @@ const commonColors: SyntaxColors = (tokens) => {
       settings: tokens.keyword.default
     },
     {
+      name: 'Flow control',
+      scope: 'keyword.control',
+      settings: tokens.keyword.control
+    },
+    {
+      name: 'Operator',
+      scope: 'keyword.operator',
+      settings: tokens.keyword.operator
+    },
+    {
+      name: 'Modifier',
+      scope: 'storage.modifier',
+      settings: tokens.keyword.modifier
+    },
+    {
+      name: 'Other keywords',
+      scope: 'keyword.other',
+      settings: tokens.keyword.other
+    },
+
+    {
       name: 'Language variable',
       scope: ['variable.language', 'support.variable'],
       settings: tokens.type.languageConstant.default
@@ -19,11 +40,6 @@ const commonColors: SyntaxColors = (tokens) => {
       name: 'Language class',
       scope: 'support.class',
       settings: tokens.type.typeName
-    },
-    {
-      name: 'Modifier',
-      scope: 'storage.modifier',
-      settings: tokens.keyword.modifier
     },
 
     /**

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -76,11 +76,7 @@ const commonColors: SyntaxColors = (tokens) => {
     },
     {
       name: 'Object property',
-      scope: [
-        'string.unquoted',
-        'meta.object-literal.key',
-        'variable.object.property'
-      ],
+      scope: ['meta.object-literal.key', 'variable.object.property'],
       settings: tokens.object.property
     },
 
@@ -138,9 +134,11 @@ const commonColors: SyntaxColors = (tokens) => {
       name: 'String',
       scope: [
         'string',
-        'string.quoted.single',
-        'string.quoted.double',
-        'string.quoted.template'
+        'string.quoted',
+        'string.unquoted',
+        'string.interpolated',
+        'string.regexp',
+        'string.other'
       ],
       settings: tokens.type.string
     },

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -13,7 +13,7 @@ const commonColors: SyntaxColors = (tokens) => {
     {
       name: 'Language variable',
       scope: ['variable.language', 'support.variable'],
-      settings: tokens.type.special
+      settings: tokens.type.languageConstant.default
     },
     {
       name: 'Language class',
@@ -145,7 +145,7 @@ const commonColors: SyntaxColors = (tokens) => {
     {
       name: 'Language constant (boolean, null)',
       scope: 'constant.language',
-      settings: tokens.type.special
+      settings: tokens.type.languageConstant.default
     },
     {
       name: 'Custom type',

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -113,6 +113,16 @@ const commonColors: SyntaxColors = (tokens) => {
      * Types
      */
     {
+      name: 'Character',
+      scope: 'constant.character',
+      settings: tokens.type.character.default
+    },
+    {
+      name: 'Escape character',
+      scope: 'constant.character.escape',
+      settings: tokens.type.character.escape
+    },
+    {
       name: 'String',
       scope: [
         'string',

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -159,6 +159,23 @@ const commonColors: SyntaxColors = (tokens) => {
     },
 
     /**
+     * Tags
+     */
+    {
+      name: 'Tag',
+      scope: 'entity.name.tag',
+      settings: tokens.tag.name
+    },
+    {
+      name: 'Tag angle brackets',
+      scope: [
+        'punctuation.definition.tag.begin',
+        'punctuation.definition.tag.end'
+      ],
+      settings: tokens.tag.name
+    },
+
+    /**
      * Other
      */
     {

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -148,7 +148,7 @@ const commonColors: SyntaxColors = (tokens) => {
      */
     {
       name: 'Comment',
-      scope: ['comment', 'punctuation.definition.comment'],
+      scope: 'comment',
       settings: tokens.comment
     },
     {

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -101,15 +101,6 @@ const commonColors: SyntaxColors = (tokens) => {
     },
 
     /**
-     * Modules
-     */
-    {
-      name: 'Module name',
-      scope: 'entity.name.type.module',
-      settings: tokens.module.name
-    },
-
-    /**
      * Types
      */
     {
@@ -156,6 +147,15 @@ const commonColors: SyntaxColors = (tokens) => {
       name: 'Custom type',
       scope: 'entity.name.type',
       settings: tokens.type.custom
+    },
+
+    /**
+     * Modules
+     */
+    {
+      name: 'Module name',
+      scope: 'entity.name.type.module',
+      settings: tokens.module.name
     },
 
     /**

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -7,7 +7,7 @@ const commonColors: SyntaxColors = (tokens) => {
      */
     {
       name: 'Keywords',
-      scope: ['keyword', 'support.type'],
+      scope: 'keyword',
       settings: tokens.keyword.default
     },
     {
@@ -36,17 +36,6 @@ const commonColors: SyntaxColors = (tokens) => {
       settings: tokens.keyword.other
     },
 
-    {
-      name: 'Language variable',
-      scope: ['variable.language', 'support.variable'],
-      settings: tokens.type.languageConstant.default
-    },
-    {
-      name: 'Language class',
-      scope: 'support.class',
-      settings: tokens.type.typeName
-    },
-
     /**
      * Variables
      */
@@ -59,6 +48,16 @@ const commonColors: SyntaxColors = (tokens) => {
       name: 'Constant',
       scope: 'variable.other.constant',
       settings: tokens.constant
+    },
+    {
+      name: 'Language variable',
+      scope: 'variable.language',
+      settings: tokens.type.constant.language
+    },
+    {
+      name: 'Library variable',
+      scope: 'support.variable',
+      settings: tokens.type.constant.library
     },
 
     /**
@@ -89,9 +88,9 @@ const commonColors: SyntaxColors = (tokens) => {
       settings: tokens.function.name
     },
     {
-      name: 'Language function',
+      name: 'Library function',
       scope: 'support.function',
-      settings: tokens.function.name
+      settings: tokens.function.library
     },
     {
       name: 'Function parameter',
@@ -115,6 +114,11 @@ const commonColors: SyntaxColors = (tokens) => {
       name: 'Instance',
       scope: ['entity.name.type.instance', 'variable.other.class'],
       settings: tokens.class.name
+    },
+    {
+      name: 'Library class',
+      scope: 'support.class',
+      settings: tokens.class.library
     },
 
     /**
@@ -148,18 +152,23 @@ const commonColors: SyntaxColors = (tokens) => {
       settings: tokens.type.number
     },
     {
-      name: 'Primitive type',
-      scope: 'support.type.primitive',
-      settings: tokens.type.primitive
+      name: 'Library type',
+      scope: 'support.type',
+      settings: tokens.type.library
     },
     {
       name: 'Language constant (boolean, null)',
       scope: 'constant.language',
-      settings: tokens.type.languageConstant.default
+      settings: tokens.type.constant.language
+    },
+    {
+      name: 'Library constant',
+      scope: 'support.constant',
+      settings: tokens.type.constant.library
     },
     {
       name: 'Other constant',
-      scope: 'constant.other',
+      scope: ['constant.other', 'support.other'],
       settings: tokens.type.other
     },
     {

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -7,7 +7,7 @@ const commonColors: SyntaxColors = (tokens) => {
      */
     {
       name: 'Keywords',
-      scope: ['keyword', 'storage.type', 'support.type'],
+      scope: ['keyword', 'support.type'],
       settings: tokens.keyword.default
     },
     {
@@ -21,7 +21,12 @@ const commonColors: SyntaxColors = (tokens) => {
       settings: tokens.keyword.operator
     },
     {
-      name: 'Modifier',
+      name: 'Type name (class, function, int, var)',
+      scope: 'storage.type',
+      settings: tokens.type.typeName
+    },
+    {
+      name: 'Modifier (static, final, abstract)',
       scope: 'storage.modifier',
       settings: tokens.keyword.modifier
     },

--- a/src/colors/syntax/css.colors.ts
+++ b/src/colors/syntax/css.colors.ts
@@ -64,7 +64,7 @@ const cssColors: SyntaxColors = (tokens) => {
       settings: tokens.css.function.parameter
     },
     {
-      name: 'Unit', // keyword.default
+      name: 'Unit',
       scope: 'keyword.other.unit',
       settings: tokens.css.unit
     }

--- a/src/colors/syntax/css.colors.ts
+++ b/src/colors/syntax/css.colors.ts
@@ -64,11 +64,6 @@ const cssColors: SyntaxColors = (tokens) => {
       settings: tokens.css.function.parameter
     },
     {
-      name: 'Number', // type.number
-      scope: 'constant.numeric.css',
-      settings: tokens.css.function.parameter
-    },
-    {
       name: 'Unit', // keyword.default
       scope: 'keyword.other.unit',
       settings: tokens.css.unit

--- a/src/colors/syntax/html.colors.ts
+++ b/src/colors/syntax/html.colors.ts
@@ -25,11 +25,6 @@ const htmlColors: SyntaxColors = (tokens) => {
       scope: 'text.html.derivative',
       settings: tokens.text
     },
-    {
-      name: 'Special character', // constant.character
-      scope: 'constant.character.entity',
-      settings: tokens.type.character.default
-    },
 
     /**
      * Components

--- a/src/colors/syntax/html.colors.ts
+++ b/src/colors/syntax/html.colors.ts
@@ -3,19 +3,6 @@ import { SyntaxColors } from '../../types/colors-types';
 const htmlColors: SyntaxColors = (tokens) => {
   return [
     {
-      name: 'Tag',
-      scope: 'entity.name.tag',
-      settings: tokens.html.tag
-    },
-    {
-      name: 'Tag angle brackets',
-      scope: [
-        'punctuation.definition.tag.begin',
-        'punctuation.definition.tag.end'
-      ],
-      settings: tokens.html.tag
-    },
-    {
       name: 'Attribute',
       scope: ['meta.tag', 'meta.tag.inline.any'],
       settings: tokens.html.attribute

--- a/src/colors/syntax/index.ts
+++ b/src/colors/syntax/index.ts
@@ -2,6 +2,7 @@ import commonColors from './common.colors';
 import configColors from './config.colors';
 import cssColors from './css.colors';
 import htmlColors from './html.colors';
+import jsColors from './js.colors';
 import jsonColors from './json.colors';
 import jsxColors from './jsx.colors';
 import markupColors from './markup.colors';
@@ -16,6 +17,7 @@ export default {
   configColors,
   cssColors,
   htmlColors,
+  jsColors,
   jsonColors,
   jsxColors,
   markupColors,

--- a/src/colors/syntax/index.ts
+++ b/src/colors/syntax/index.ts
@@ -4,6 +4,7 @@ import cssColors from './css.colors';
 import htmlColors from './html.colors';
 import jsonColors from './json.colors';
 import jsxColors from './jsx.colors';
+import markupColors from './markup.colors';
 import mdColors from './md.colors';
 import pugColors from './pug.colors';
 import tsColors from './ts.colors';
@@ -17,6 +18,7 @@ export default {
   htmlColors,
   jsonColors,
   jsxColors,
+  markupColors,
   mdColors,
   pugColors,
   tsColors,

--- a/src/colors/syntax/js.colors.ts
+++ b/src/colors/syntax/js.colors.ts
@@ -1,0 +1,13 @@
+import { SyntaxColors } from '../../types/colors-types';
+
+const jsColors: SyntaxColors = (tokens) => {
+  return [
+    {
+      name: 'Object property',
+      scope: 'string.unquoted.js',
+      settings: tokens.object.property
+    }
+  ];
+};
+
+export default jsColors;

--- a/src/colors/syntax/json.colors.ts
+++ b/src/colors/syntax/json.colors.ts
@@ -8,7 +8,7 @@ const jsonColors: SyntaxColors = (tokens) => {
     {
       name: 'Language constant (boolean, null)',
       scope: 'constant.language.json',
-      settings: tokens.type.languageConstant.alternative
+      settings: tokens.type.constant.languageAlt
     },
 
     /**

--- a/src/colors/syntax/json.colors.ts
+++ b/src/colors/syntax/json.colors.ts
@@ -6,9 +6,9 @@ const jsonColors: SyntaxColors = (tokens) => {
      * Scalars
      */
     {
-      name: 'Boolean', // type.special
+      name: 'Language constant (boolean, null)',
       scope: 'constant.language.json',
-      settings: tokens.json.boolean
+      settings: tokens.type.languageConstant.alternative
     },
     {
       name: 'String', // type.string

--- a/src/colors/syntax/json.colors.ts
+++ b/src/colors/syntax/json.colors.ts
@@ -10,11 +10,6 @@ const jsonColors: SyntaxColors = (tokens) => {
       scope: 'constant.language.json',
       settings: tokens.type.languageConstant.alternative
     },
-    {
-      name: 'String', // type.string
-      scope: 'string.quoted.double.json',
-      settings: tokens.type.string
-    },
 
     /**
      * Properties

--- a/src/colors/syntax/json.colors.ts
+++ b/src/colors/syntax/json.colors.ts
@@ -11,11 +11,6 @@ const jsonColors: SyntaxColors = (tokens) => {
       settings: tokens.json.boolean
     },
     {
-      name: 'Number', // type.number
-      scope: 'constant.numeric.json',
-      settings: tokens.json.number
-    },
-    {
       name: 'String', // type.string
       scope: 'string.quoted.double.json',
       settings: tokens.type.string

--- a/src/colors/syntax/markup.colors.ts
+++ b/src/colors/syntax/markup.colors.ts
@@ -1,0 +1,76 @@
+import { SyntaxColors } from '../../types/colors-types';
+
+const markupColors: SyntaxColors = (tokens) => {
+  return [
+    /**
+     * Heading
+     */
+    {
+      name: 'Markup: Heading',
+      scope: 'markup.heading',
+      settings: tokens.markup.heading
+    },
+
+    /**
+     * Style
+     */
+    {
+      name: 'Markup: Bold text',
+      scope: 'markup.bold',
+      settings: tokens.markup.bold
+    },
+    {
+      name: 'Markup: Italic text',
+      scope: 'markup.italic',
+      settings: tokens.markup.italic
+    },
+    {
+      name: 'Markup: Underline text',
+      scope: 'markup.underline',
+      settings: tokens.markup.underline
+    },
+
+    /**
+     * Link
+     */
+    {
+      name: 'Markup: Link',
+      scope: 'markup.underline.link',
+      settings: tokens.markup.link
+    },
+
+    /**
+     * Quote
+     */
+    {
+      name: 'Markup: Quote',
+      scope: 'markup.quote',
+      settings: tokens.markup.quote
+    },
+
+    /**
+     * Raw text (code)
+     */
+    {
+      name: 'Markup: Raw text',
+      scope: 'markup.raw',
+      settings: tokens.markup.raw
+    },
+
+    /**
+     * List items
+     */
+    {
+      name: 'Markup: Numbered list items',
+      scope: 'markup.list.numbered',
+      settings: tokens.markup.list.numbered
+    },
+    {
+      name: 'Markup: Unnumbered list items',
+      scope: 'markup.list.unnumbered',
+      settings: tokens.markup.list.unnumbered
+    }
+  ];
+};
+
+export default markupColors;

--- a/src/colors/syntax/md.colors.ts
+++ b/src/colors/syntax/md.colors.ts
@@ -6,11 +6,6 @@ const mdColors: SyntaxColors = (tokens) => {
      * Heading
      */
     {
-      name: 'MD: Heading', // markup.heading
-      scope: 'markup.heading.markdown',
-      settings: tokens.markup.heading
-    },
-    {
       name: 'MD: Heading punctuation (# title)',
       scope: 'punctuation.definition.heading.markdown',
       settings: tokens.markdown.puntuaction.heading
@@ -20,20 +15,9 @@ const mdColors: SyntaxColors = (tokens) => {
      * Style
      */
     {
-      name: 'MD: Bold text', // markup.bold
-      scope: 'markup.bold.markdown',
-      settings: tokens.markup.bold
-    },
-    {
       name: 'MD: Bold puntuation (**text**)',
       scope: 'punctuation.definition.bold.markdown',
       settings: tokens.markdown.puntuaction.bold
-    },
-
-    {
-      name: 'MD: Italic text', // markup.italic
-      scope: 'markup.italic.markdown',
-      settings: tokens.markup.italic
     },
     {
       name: 'MD: Italic puntuation (__text__)',
@@ -44,12 +28,6 @@ const mdColors: SyntaxColors = (tokens) => {
     /**
      * Quote
      */
-
-    {
-      name: 'MD: Quote', // markup.quote
-      scope: 'markup.quote.markdown',
-      settings: tokens.markup.quote
-    },
     {
       name: 'MD: Quote puntuaction (> text)',
       scope: 'punctuation.definition.quote.begin.markdown',
@@ -68,14 +46,6 @@ const mdColors: SyntaxColors = (tokens) => {
       settings: tokens.markdown.linkTitle
     },
     {
-      name: 'MD: Link', // markup.link
-      scope: [
-        'markup.underline.link.markdown',
-        'markup.underline.link.image.markdown'
-      ],
-      settings: tokens.markup.link
-    },
-    {
       name: 'MD: Link punctuation',
       scope: [
         'punctuation.definition.string.begin.markdown',
@@ -86,19 +56,17 @@ const mdColors: SyntaxColors = (tokens) => {
     },
 
     /**
-     * Code
+     * Raw text (code)
      */
     {
       name: 'MD: Inline code',
       scope: 'markup.inline.raw.string.markdown',
       settings: tokens.markup.raw
     },
-    {
-      name: 'MD: Block code',
-      scope: 'markup.raw.block.markdown',
-      settings: tokens.markup.raw
-    },
 
+    /**
+     * Lists
+     */
     {
       name: 'MD: List puntuation',
       scope: 'punctuation.definition.list.begin.markdown',

--- a/src/colors/syntax/yml.colors.ts
+++ b/src/colors/syntax/yml.colors.ts
@@ -10,11 +10,6 @@ const ymlColors: SyntaxColors = (tokens) => {
       scope: ['constant.language.boolean.yaml', 'constant.language.null.yaml'],
       settings: tokens.type.languageConstant.alternative
     },
-    {
-      name: 'String', // string
-      scope: 'string.unquoted.plain.out.yaml',
-      settings: tokens.type.string
-    },
 
     /**
      * Properties

--- a/src/colors/syntax/yml.colors.ts
+++ b/src/colors/syntax/yml.colors.ts
@@ -8,7 +8,7 @@ const ymlColors: SyntaxColors = (tokens) => {
     {
       name: 'Language constant (boolean, null)',
       scope: ['constant.language.boolean.yaml', 'constant.language.null.yaml'],
-      settings: tokens.type.languageConstant.alternative
+      settings: tokens.type.constant.languageAlt
     },
 
     /**

--- a/src/colors/syntax/yml.colors.ts
+++ b/src/colors/syntax/yml.colors.ts
@@ -11,11 +11,6 @@ const ymlColors: SyntaxColors = (tokens) => {
       settings: tokens.yaml.boolean
     },
     {
-      name: 'Number', // type.number
-      scope: 'constant.numeric.integer.yaml',
-      settings: tokens.yaml.number
-    },
-    {
       name: 'String', // string
       scope: 'string.unquoted.plain.out.yaml',
       settings: tokens.type.string

--- a/src/colors/syntax/yml.colors.ts
+++ b/src/colors/syntax/yml.colors.ts
@@ -6,9 +6,9 @@ const ymlColors: SyntaxColors = (tokens) => {
      * Scalars
      */
     {
-      name: 'Boolean', // type.special
-      scope: 'constant.language.boolean.yaml',
-      settings: tokens.yaml.boolean
+      name: 'Language constant (boolean, null)',
+      scope: ['constant.language.boolean.yaml', 'constant.language.null.yaml'],
+      settings: tokens.type.languageConstant.alternative
     },
     {
       name: 'String', // string

--- a/src/colors/syntax/yml.colors.ts
+++ b/src/colors/syntax/yml.colors.ts
@@ -20,7 +20,7 @@ const ymlColors: SyntaxColors = (tokens) => {
      * Properties
      */
     {
-      name: 'Property name', // entity.name.tag
+      name: 'Property name',
       scope: 'entity.name.tag.yaml',
       settings: tokens.tag.name
     }

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -43,7 +43,7 @@ const type: Type = {
       foreground: pink[1]
     },
     escape: {
-      foreground: ''
+      foreground: purple[2]
     }
   },
   custom: {

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -251,12 +251,8 @@ const css: Css = {
     }
   },
 
-  number: {
-    foreground: green[2]
-  },
-
   unit: {
-    foreground: purple[2]
+    foreground: pink[1]
   }
 };
 
@@ -285,9 +281,6 @@ const html: Html = {
  */
 const json: Json = {
   boolean: {
-    foreground: indigo[2]
-  },
-  number: {
     foreground: indigo[2]
   },
   property: {
@@ -376,9 +369,6 @@ const markdown: Markdown = {
  */
 const yaml: Yaml = {
   boolean: {
-    foreground: indigo[2]
-  },
-  number: {
     foreground: indigo[2]
   }
 };

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -52,7 +52,7 @@ const type: Type = {
     foreground: orange[2]
   },
   other: {
-    foreground: ''
+    foreground: purple[2]
   },
   languageConstant: {
     default: {

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -17,7 +17,6 @@ import {
   Tag,
   Tokens,
   Type,
-  Yaml,
 } from '../../types/tokens-types';
 import { palette } from './palette';
 
@@ -55,8 +54,13 @@ const type: Type = {
   other: {
     foreground: ''
   },
-  special: {
-    foreground: purple[2]
+  languageConstant: {
+    default: {
+      foreground: purple[2]
+    },
+    alternative: {
+      foreground: blue[2]
+    }
   },
   string: {
     foreground: green[2]
@@ -280,9 +284,6 @@ const html: Html = {
  * JSON
  */
 const json: Json = {
-  boolean: {
-    foreground: indigo[2]
-  },
   property: {
     foreground: purple[2]
   }
@@ -364,15 +365,6 @@ const markdown: Markdown = {
   }
 };
 
-/**
- * YAML
- */
-const yaml: Yaml = {
-  boolean: {
-    foreground: indigo[2]
-  }
-};
-
 export const tokens: Tokens = {
   type,
   keyword,
@@ -393,6 +385,5 @@ export const tokens: Tokens = {
   json,
   tag,
   markup,
-  markdown,
-  yaml
+  markdown
 };

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -17,6 +17,7 @@ import {
   Tag,
   Tokens,
   Type,
+  Variable,
 } from '../../types/tokens-types';
 import { palette } from './palette';
 
@@ -100,15 +101,13 @@ const keyword: Keyword = {
 /**
  * Variables
  */
-const variable: Settings = {
-  foreground: pink[1]
-};
-
-/**
- * Constant
- */
-const constant: Settings = {
-  foreground: pink[1]
+const variable: Variable = {
+  default: {
+    foreground: pink[1]
+  },
+  other: {
+    foreground: pink[1]
+  }
 };
 
 /**
@@ -373,7 +372,6 @@ export const tokens: Tokens = {
   type,
   keyword,
   variable,
-  constant,
   object,
   function: functionType,
   class: classType,

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -303,7 +303,8 @@ const json: Json = {
 const markup: Markup = {
   // Links
   link: {
-    foreground: blue[2]
+    foreground: blue[2],
+    fontStyle: 'underline'
   },
 
   // Text
@@ -319,10 +320,15 @@ const markup: Markup = {
     fontStyle: 'italic'
   },
   list: {
-    foreground: ''
+    numbered: {
+      foreground: text.foreground
+    },
+    unnumbered: {
+      foreground: text.foreground
+    }
   },
   other: {
-    foreground: ''
+    foreground: text.foreground
   },
   quote: {
     foreground: green[2]
@@ -331,7 +337,8 @@ const markup: Markup = {
     foreground: teal[2]
   },
   underline: {
-    foreground: ''
+    foreground: blue[2],
+    fontStyle: 'underline'
   }
 };
 
@@ -340,24 +347,16 @@ const markup: Markup = {
  */
 const markdown: Markdown = {
   puntuaction: {
-    heading: {
-      foreground: purple[1]
-    },
-    bold: {
-      foreground: pink[1]
-    },
-    italic: {
-      foreground: orange[1]
-    },
-    quote: {
-      foreground: green[1]
-    },
+    heading: markup.heading,
+    bold: markup.bold,
+    italic: markup.italic,
+    quote: markup.quote,
     list: {
       foreground: purple[2]
     }
   },
   linkTitle: {
-    foreground: blue[1]
+    foreground: markup.link.foreground
   }
 };
 

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -261,15 +261,23 @@ const css: Css = {
 };
 
 /**
- * HTML
+ * Tags
  */
-const html: Html = {
-  tag: {
-    foreground: purple[2]
-  },
+const tag: Tag = {
   attribute: {
     foreground: indigo[2]
   },
+  name: {
+    foreground: purple[2]
+  }
+};
+
+/**
+ * HTML
+ */
+const html: Html = {
+  tag: tag.name,
+  attribute: tag.attribute,
   component: {
     tag: {
       foreground: orange[2]
@@ -285,18 +293,6 @@ const html: Html = {
  */
 const json: Json = {
   property: {
-    foreground: purple[2]
-  }
-};
-
-/**
- * Tags
- */
-const tag: Tag = {
-  attributeName: {
-    foreground: ''
-  },
-  name: {
     foreground: purple[2]
   }
 };

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -66,7 +66,7 @@ const type: Type = {
     foreground: green[2]
   },
   typeName: {
-    foreground: blue[2]
+    foreground: purple[2]
   },
   primitive: {
     foreground: teal[2]

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -54,12 +54,15 @@ const type: Type = {
   other: {
     foreground: purple[2]
   },
-  languageConstant: {
-    default: {
+  constant: {
+    language: {
       foreground: purple[2]
     },
-    alternative: {
+    languageAlt: {
       foreground: blue[2]
+    },
+    library: {
+      foreground: purple[2]
     }
   },
   string: {
@@ -68,8 +71,8 @@ const type: Type = {
   typeName: {
     foreground: purple[2]
   },
-  primitive: {
-    foreground: teal[2]
+  library: {
+    foreground: purple[2]
   }
 };
 
@@ -126,6 +129,9 @@ const functionType: FunctionType = {
   },
   parameter: {
     foreground: pink[1]
+  },
+  library: {
+    foreground: blue[2]
   }
 };
 
@@ -137,6 +143,9 @@ const classType: ClassType = {
     foreground: blue[2]
   },
   baseClass: {
+    foreground: blue[2]
+  },
+  library: {
     foreground: blue[2]
   }
 };

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -28,6 +28,12 @@ export interface Keyword {
   other: Settings;
 }
 
+// Variables
+export interface Variable {
+  default: Settings;
+  other: Settings;
+}
+
 // Objects
 export interface ObjectType {
   property: Settings;
@@ -154,8 +160,7 @@ export interface Markdown {
 export interface Tokens {
   type: Type;
   keyword: Keyword;
-  variable: Settings;
-  constant: Settings;
+  variable: Variable;
   object: ObjectType;
   function: FunctionType;
   class: ClassType;

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -69,7 +69,10 @@ export interface Markup {
   bold: Settings;
   italic: Settings;
   underline: Settings;
-  list: Settings;
+  list: {
+    numbered: Settings;
+    unnumbered: Settings;
+  };
   quote: Settings;
   raw: Settings;
   other: Settings;

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -112,7 +112,6 @@ export interface Css {
     parameter: Settings;
   };
 
-  number: Settings;
   unit: Settings;
 }
 
@@ -129,7 +128,6 @@ export interface Html {
 // JSON
 export interface Json {
   boolean: Settings;
-  number: Settings;
   property: Settings;
 }
 
@@ -148,7 +146,6 @@ export interface Markdown {
 // YAML
 export interface Yaml {
   boolean: Settings;
-  number: Settings;
 }
 
 export interface Tokens {

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -8,14 +8,15 @@ export interface Type {
     default: Settings; // constant.character
     escape: Settings; // constant.character.escape
   };
-  languageConstant: {
-    default: Settings; // constant.language
-    alternative: Settings;
+  constant: {
+    language: Settings; // constant.language
+    languageAlt: Settings;
+    library: Settings; // support.constant
   };
   custom: Settings; // entity.name.type
   other: Settings; // constant.other
   typeName: Settings; // storage.type
-  primitive: Settings;
+  library: Settings; // support.type
 }
 
 // Keywords
@@ -36,12 +37,14 @@ export interface ObjectType {
 export interface FunctionType {
   name: Settings; // entity.name.function
   parameter: Settings; // variable.parameter
+  library: Settings; // support.function
 }
 
 // Classes
 export interface ClassType {
   name: Settings;
   baseClass: Settings; // entity.other.inherited-class
+  library: Settings; // support.class
 }
 
 // Modules

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -8,7 +8,10 @@ export interface Type {
     default: Settings; // constant.character
     escape: Settings; // constant.character.escape
   };
-  special: Settings; // constant.language
+  languageConstant: {
+    default: Settings; // constant.language
+    alternative: Settings;
+  };
   custom: Settings; // entity.name.type
   other: Settings; // constant.other
   typeName: Settings; // storage.type
@@ -127,7 +130,6 @@ export interface Html {
 
 // JSON
 export interface Json {
-  boolean: Settings;
   property: Settings;
 }
 
@@ -141,11 +143,6 @@ export interface Markdown {
     list: Settings;
   };
   linkTitle: Settings;
-}
-
-// YAML
-export interface Yaml {
-  boolean: Settings;
 }
 
 export interface Tokens {
@@ -169,7 +166,6 @@ export interface Tokens {
   html: Html;
   json: Json;
   markdown: Markdown;
-  yaml: Yaml;
 }
 
 export interface Settings {

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -57,7 +57,7 @@ export interface Section {
 // Tags
 export interface Tag {
   name: Settings; // entity.name.tag
-  attributeName: Settings; // entity.other.attribute-name
+  attribute: Settings; // entity.other.attribute-name
 }
 
 // Markup

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -385,6 +385,16 @@
       "settings": { "foreground": "#90CAF9" }
     },
     {
+      "name": "Character",
+      "scope": "constant.character",
+      "settings": { "foreground": "#F8BBD0" }
+    },
+    {
+      "name": "Escape character",
+      "scope": "constant.character.escape",
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
       "name": "String",
       "scope": [
         "string",
@@ -531,11 +541,6 @@
       "name": "Text",
       "scope": "text.html.derivative",
       "settings": { "foreground": "#ECEFF1" }
-    },
-    {
-      "name": "Special character",
-      "scope": "constant.character.entity",
-      "settings": { "foreground": "#F8BBD0" }
     },
     {
       "name": "Component tag",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -416,7 +416,7 @@
     },
     {
       "name": "Comment",
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": "comment",
       "settings": { "foreground": "#90A4AE" }
     },
     {

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -303,7 +303,7 @@
   "tokenColors": [
     {
       "name": "Keywords",
-      "scope": ["keyword", "storage.type", "support.type"],
+      "scope": ["keyword", "support.type"],
       "settings": { "foreground": "#B39DDB" }
     },
     {
@@ -317,7 +317,12 @@
       "settings": { "foreground": "#B39DDB" }
     },
     {
-      "name": "Modifier",
+      "name": "Type name (class, function, int, var)",
+      "scope": "storage.type",
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
+      "name": "Modifier (static, final, abstract)",
       "scope": "storage.modifier",
       "settings": { "foreground": "#B39DDB" }
     },
@@ -334,7 +339,7 @@
     {
       "name": "Language class",
       "scope": "support.class",
-      "settings": { "foreground": "#90CAF9" }
+      "settings": { "foreground": "#B39DDB" }
     },
     {
       "name": "Variable",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -303,7 +303,7 @@
   "tokenColors": [
     {
       "name": "Keywords",
-      "scope": ["keyword", "support.type"],
+      "scope": "keyword",
       "settings": { "foreground": "#B39DDB" }
     },
     {
@@ -332,16 +332,6 @@
       "settings": { "foreground": "#B39DDB" }
     },
     {
-      "name": "Language variable",
-      "scope": ["variable.language", "support.variable"],
-      "settings": { "foreground": "#B39DDB" }
-    },
-    {
-      "name": "Language class",
-      "scope": "support.class",
-      "settings": { "foreground": "#B39DDB" }
-    },
-    {
       "name": "Variable",
       "scope": "variable",
       "settings": { "foreground": "#F8BBD0" }
@@ -350,6 +340,16 @@
       "name": "Constant",
       "scope": "variable.other.constant",
       "settings": { "foreground": "#F8BBD0" }
+    },
+    {
+      "name": "Language variable",
+      "scope": "variable.language",
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
+      "name": "Library variable",
+      "scope": "support.variable",
+      "settings": { "foreground": "#B39DDB" }
     },
     {
       "name": "Object variable",
@@ -372,7 +372,7 @@
       "settings": { "foreground": "#90CAF9" }
     },
     {
-      "name": "Language function",
+      "name": "Library function",
       "scope": "support.function",
       "settings": { "foreground": "#90CAF9" }
     },
@@ -393,6 +393,11 @@
     {
       "name": "Instance",
       "scope": ["entity.name.type.instance", "variable.other.class"],
+      "settings": { "foreground": "#90CAF9" }
+    },
+    {
+      "name": "Library class",
+      "scope": "support.class",
       "settings": { "foreground": "#90CAF9" }
     },
     {
@@ -423,9 +428,9 @@
       "settings": { "foreground": "#FFCC80" }
     },
     {
-      "name": "Primitive type",
-      "scope": "support.type.primitive",
-      "settings": { "foreground": "#80DEEA" }
+      "name": "Library type",
+      "scope": "support.type",
+      "settings": { "foreground": "#B39DDB" }
     },
     {
       "name": "Language constant (boolean, null)",
@@ -433,8 +438,13 @@
       "settings": { "foreground": "#B39DDB" }
     },
     {
+      "name": "Library constant",
+      "scope": "support.constant",
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
       "name": "Other constant",
-      "scope": "constant.other",
+      "scope": ["constant.other", "support.other"],
       "settings": { "foreground": "#B39DDB" }
     },
     {

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -505,14 +505,9 @@
       "settings": { "foreground": "#A5D6A7" }
     },
     {
-      "name": "Number",
-      "scope": "constant.numeric.css",
-      "settings": { "foreground": "#A5D6A7" }
-    },
-    {
       "name": "Unit",
       "scope": "keyword.other.unit",
-      "settings": { "foreground": "#B39DDB" }
+      "settings": { "foreground": "#F8BBD0" }
     },
     {
       "name": "Tag",
@@ -559,11 +554,6 @@
     {
       "name": "Boolean",
       "scope": "constant.language.json",
-      "settings": { "foreground": "#9FA8DA" }
-    },
-    {
-      "name": "Number",
-      "scope": "constant.numeric.json",
       "settings": { "foreground": "#9FA8DA" }
     },
     {
@@ -728,11 +718,6 @@
     {
       "name": "Boolean",
       "scope": "constant.language.boolean.yaml",
-      "settings": { "foreground": "#9FA8DA" }
-    },
-    {
-      "name": "Number",
-      "scope": "constant.numeric.integer.yaml",
       "settings": { "foreground": "#9FA8DA" }
     },
     {

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -420,6 +420,11 @@
       "settings": { "foreground": "#B39DDB" }
     },
     {
+      "name": "Other constant",
+      "scope": "constant.other",
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
       "name": "Custom type",
       "scope": "entity.name.type",
       "settings": { "foreground": "#80DEEA" }

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -380,11 +380,6 @@
       "settings": { "foreground": "#90CAF9" }
     },
     {
-      "name": "Module name",
-      "scope": "entity.name.type.module",
-      "settings": { "foreground": "#90CAF9" }
-    },
-    {
       "name": "Character",
       "scope": "constant.character",
       "settings": { "foreground": "#F8BBD0" }
@@ -430,6 +425,10 @@
       "settings": { "foreground": "#80DEEA" }
     },
     {
+      "name": "Module name",
+      "scope": "entity.name.type.module",
+      "settings": { "foreground": "#90CAF9" }
+    },
       "name": "Comment",
       "scope": "comment",
       "settings": { "foreground": "#90A4AE" }

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -307,6 +307,26 @@
       "settings": { "foreground": "#B39DDB" }
     },
     {
+      "name": "Flow control",
+      "scope": "keyword.control",
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
+      "name": "Operator",
+      "scope": "keyword.operator",
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
+      "name": "Modifier",
+      "scope": "storage.modifier",
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
+      "name": "Other keywords",
+      "scope": "keyword.other",
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
       "name": "Language variable",
       "scope": ["variable.language", "support.variable"],
       "settings": { "foreground": "#B39DDB" }
@@ -315,11 +335,6 @@
       "name": "Language class",
       "scope": "support.class",
       "settings": { "foreground": "#90CAF9" }
-    },
-    {
-      "name": "Modifier",
-      "scope": "storage.modifier",
-      "settings": { "foreground": "#B39DDB" }
     },
     {
       "name": "Variable",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -363,11 +363,7 @@
     },
     {
       "name": "Object property",
-      "scope": [
-        "string.unquoted",
-        "meta.object-literal.key",
-        "variable.object.property"
-      ],
+      "scope": ["meta.object-literal.key", "variable.object.property"],
       "settings": { "foreground": "#9FA8DA" }
     },
     {
@@ -413,9 +409,11 @@
       "name": "String",
       "scope": [
         "string",
-        "string.quoted.single",
-        "string.quoted.double",
-        "string.quoted.template"
+        "string.quoted",
+        "string.unquoted",
+        "string.interpolated",
+        "string.regexp",
+        "string.other"
       ],
       "settings": { "foreground": "#A5D6A7" }
     },
@@ -587,14 +585,14 @@
       "settings": { "foreground": "#FFCC80" }
     },
     {
+      "name": "Object property",
+      "scope": "string.unquoted.js",
+      "settings": { "foreground": "#9FA8DA" }
+    },
+    {
       "name": "Language constant (boolean, null)",
       "scope": "constant.language.json",
       "settings": { "foreground": "#90CAF9" }
-    },
-    {
-      "name": "String",
-      "scope": "string.quoted.double.json",
-      "settings": { "foreground": "#A5D6A7" }
     },
     {
       "name": "Property name",
@@ -769,11 +767,6 @@
         "constant.language.null.yaml"
       ],
       "settings": { "foreground": "#90CAF9" }
-    },
-    {
-      "name": "String",
-      "scope": "string.unquoted.plain.out.yaml",
-      "settings": { "foreground": "#A5D6A7" }
     },
     {
       "name": "Property name",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -636,58 +636,75 @@
       "settings": { "foreground": "#ECEFF1" }
     },
     {
-      "name": "MD: Heading",
-      "scope": "markup.heading.markdown",
+      "name": "Markup: Heading",
+      "scope": "markup.heading",
       "settings": { "foreground": "#B39DDB" }
+    },
+    {
+      "name": "Markup: Bold text",
+      "scope": "markup.bold",
+      "settings": { "foreground": "#F8BBD0", "fontStyle": "bold" }
+    },
+    {
+      "name": "Markup: Italic text",
+      "scope": "markup.italic",
+      "settings": { "foreground": "#FFCC80", "fontStyle": "italic" }
+    },
+    {
+      "name": "Markup: Underline text",
+      "scope": "markup.underline",
+      "settings": { "foreground": "#90CAF9", "fontStyle": "underline" }
+    },
+    {
+      "name": "Markup: Link",
+      "scope": "markup.underline.link",
+      "settings": { "foreground": "#90CAF9", "fontStyle": "underline" }
+    },
+    {
+      "name": "Markup: Quote",
+      "scope": "markup.quote",
+      "settings": { "foreground": "#A5D6A7" }
+    },
+    {
+      "name": "Markup: Raw text",
+      "scope": "markup.raw",
+      "settings": { "foreground": "#80DEEA" }
+    },
+    {
+      "name": "Markup: Numbered list items",
+      "scope": "markup.list.numbered",
+      "settings": { "foreground": "#ECEFF1" }
+    },
+    {
+      "name": "Markup: Unnumbered list items",
+      "scope": "markup.list.unnumbered",
+      "settings": { "foreground": "#ECEFF1" }
     },
     {
       "name": "MD: Heading punctuation (# title)",
       "scope": "punctuation.definition.heading.markdown",
-      "settings": { "foreground": "#D1C4E9" }
-    },
-    {
-      "name": "MD: Bold text",
-      "scope": "markup.bold.markdown",
-      "settings": { "foreground": "#F8BBD0", "fontStyle": "bold" }
+      "settings": { "foreground": "#B39DDB" }
     },
     {
       "name": "MD: Bold puntuation (**text**)",
       "scope": "punctuation.definition.bold.markdown",
-      "settings": { "foreground": "#F8BBD0" }
-    },
-    {
-      "name": "MD: Italic text",
-      "scope": "markup.italic.markdown",
-      "settings": { "foreground": "#FFCC80", "fontStyle": "italic" }
+      "settings": { "foreground": "#F8BBD0", "fontStyle": "bold" }
     },
     {
       "name": "MD: Italic puntuation (__text__)",
       "scope": "punctuation.definition.italic.markdown",
-      "settings": { "foreground": "#FFE0B2" }
-    },
-    {
-      "name": "MD: Quote",
-      "scope": "markup.quote.markdown",
-      "settings": { "foreground": "#A5D6A7" }
+      "settings": { "foreground": "#FFCC80", "fontStyle": "italic" }
     },
     {
       "name": "MD: Quote puntuaction (> text)",
       "scope": "punctuation.definition.quote.begin.markdown",
-      "settings": { "foreground": "#C8E6C9" }
+      "settings": { "foreground": "#A5D6A7" }
     },
     {
       "name": "MD: Link title",
       "scope": [
         "string.other.link.description.markdown",
         "string.other.link.title.markdown"
-      ],
-      "settings": { "foreground": "#BBDEFB" }
-    },
-    {
-      "name": "MD: Link",
-      "scope": [
-        "markup.underline.link.markdown",
-        "markup.underline.link.image.markdown"
       ],
       "settings": { "foreground": "#90CAF9" }
     },
@@ -698,16 +715,11 @@
         "punctuation.definition.string.end.markdown",
         "punctuation.definition.metadata.markdown"
       ],
-      "settings": { "foreground": "#BBDEFB" }
+      "settings": { "foreground": "#90CAF9" }
     },
     {
       "name": "MD: Inline code",
       "scope": "markup.inline.raw.string.markdown",
-      "settings": { "foreground": "#80DEEA" }
-    },
-    {
-      "name": "MD: Block code",
-      "scope": "markup.raw.block.markdown",
       "settings": { "foreground": "#80DEEA" }
     },
     {

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -449,7 +449,12 @@
     },
     {
       "name": "Invalid",
-      "scope": ["invalid", "invalid.illegal"],
+      "scope": "invalid.illegal",
+      "settings": { "foreground": "#EF9A9A" }
+    },
+    {
+      "name": "Deprecated",
+      "scope": "invalid.deprecated",
       "settings": { "foreground": "#EF9A9A" }
     },
     {

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -429,6 +429,20 @@
       "scope": "entity.name.type.module",
       "settings": { "foreground": "#90CAF9" }
     },
+    {
+      "name": "Tag",
+      "scope": "entity.name.tag",
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
+      "name": "Tag angle brackets",
+      "scope": [
+        "punctuation.definition.tag.begin",
+        "punctuation.definition.tag.end"
+      ],
+      "settings": { "foreground": "#B39DDB" }
+    },
+    {
       "name": "Comment",
       "scope": "comment",
       "settings": { "foreground": "#90A4AE" }
@@ -522,19 +536,6 @@
       "name": "Unit",
       "scope": "keyword.other.unit",
       "settings": { "foreground": "#F8BBD0" }
-    },
-    {
-      "name": "Tag",
-      "scope": "entity.name.tag",
-      "settings": { "foreground": "#B39DDB" }
-    },
-    {
-      "name": "Tag angle brackets",
-      "scope": [
-        "punctuation.definition.tag.begin",
-        "punctuation.definition.tag.end"
-      ],
-      "settings": { "foreground": "#B39DDB" }
     },
     {
       "name": "Attribute",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -337,12 +337,12 @@
       "settings": { "foreground": "#F8BBD0" }
     },
     {
-      "name": "Constant",
-      "scope": "variable.other.constant",
+      "name": "Other variable",
+      "scope": "variable.other",
       "settings": { "foreground": "#F8BBD0" }
     },
     {
-      "name": "Language variable",
+      "name": "Language variable (this, super, self)",
       "scope": "variable.language",
       "settings": { "foreground": "#B39DDB" }
     },
@@ -352,12 +352,7 @@
       "settings": { "foreground": "#B39DDB" }
     },
     {
-      "name": "Object variable",
-      "scope": "variable.other.object",
-      "settings": { "foreground": "#F8BBD0" }
-    },
-    {
-      "name": "Variable property value",
+      "name": "Access to object property",
       "scope": "variable.other.property",
       "settings": { "foreground": "#F8BBD0" }
     },

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -557,9 +557,9 @@
       "settings": { "foreground": "#FFCC80" }
     },
     {
-      "name": "Boolean",
+      "name": "Language constant (boolean, null)",
       "scope": "constant.language.json",
-      "settings": { "foreground": "#9FA8DA" }
+      "settings": { "foreground": "#90CAF9" }
     },
     {
       "name": "String",
@@ -721,9 +721,12 @@
       "settings": { "foreground": "#FFCC80" }
     },
     {
-      "name": "Boolean",
-      "scope": "constant.language.boolean.yaml",
-      "settings": { "foreground": "#9FA8DA" }
+      "name": "Language constant (boolean, null)",
+      "scope": [
+        "constant.language.boolean.yaml",
+        "constant.language.null.yaml"
+      ],
+      "settings": { "foreground": "#90CAF9" }
     },
     {
       "name": "String",


### PR DESCRIPTION
### Changed

- **Use defined colors for an element in all languages**: green for `strings` or orange for `numbers`. If you want to see an in-depth reference, please go to color reference in the README.