### PR TITLE
fix: syntax highlight

### DIFF
--- a/demos/html/html.demo.html
+++ b/demos/html/html.demo.html
@@ -24,8 +24,8 @@
     <a href="http://codepen.io/anon/pen/xwjLbZ">
       Come look at what this shows
     </a>
-    <p>This is a paragraph.</p>
-    <p>This is another paragraph.</p>
+    <p>This is a paragraph. &AMP;</p>
+    <p>This is another paragraph. &Backslash;</p>
     <ul>
       <li>This is an item in a non-enumerated list (bullet list)</li>
       <li>This is another item</li>

--- a/src/colors/editor/activity.bar.colors.ts
+++ b/src/colors/editor/activity.bar.colors.ts
@@ -17,7 +17,7 @@ const activityBarColors: UIColors = (palette) => {
       foreground: neutral[6],
 
       // Activity bar item foreground color when it is inactive.
-      inactiveForeground: neutral[7],
+      inactiveForeground: neutral[8],
 
       // Activity Bar border color with the Side Bar.
       border: background[8]

--- a/src/colors/editor/git.colors.ts
+++ b/src/colors/editor/git.colors.ts
@@ -20,12 +20,12 @@ const gitColors: UIColors = (palette) => {
       untrackedResourceForeground: green[foregroundSwatch],
 
       // Color for ignored Git resources.
-      ignoredResourceForeground: neutral[foregroundSwatch],
+      ignoredResourceForeground: neutral[6],
 
       // Color for conflicting Git resources.
       conflictingResourceForeground: red[foregroundSwatch],
 
-      //  Color for submodule resources.
+      // Color for submodule resources.
       submoduleResourceForeground: neutral[foregroundSwatch]
     }
   };

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -52,12 +52,12 @@ const commonColors: SyntaxColors = (tokens) => {
     {
       name: 'Language variable (this, super, self)',
       scope: 'variable.language',
-      settings: tokens.type.constant.language
+      settings: tokens.keyword.other
     },
     {
       name: 'Library variable',
       scope: 'support.variable',
-      settings: tokens.type.constant.library
+      settings: tokens.variable.other
     },
 
     /**

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -195,7 +195,7 @@ const commonColors: SyntaxColors = (tokens) => {
         'punctuation.definition.tag.begin',
         'punctuation.definition.tag.end'
       ],
-      settings: tokens.tag.name
+      settings: tokens.tag.punctuation
     },
 
     /**

--- a/src/colors/syntax/css.colors.ts
+++ b/src/colors/syntax/css.colors.ts
@@ -64,6 +64,11 @@ const cssColors: SyntaxColors = (tokens) => {
       settings: tokens.css.function.parameter
     },
     {
+      name: 'CSS: Number',
+      scope: 'constant.numeric.css',
+      settings: tokens.css.number
+    },
+    {
       name: 'Unit',
       scope: 'keyword.other.unit',
       settings: tokens.css.unit

--- a/src/colors/syntax/html.colors.ts
+++ b/src/colors/syntax/html.colors.ts
@@ -5,7 +5,12 @@ const htmlColors: SyntaxColors = (tokens) => {
     {
       name: 'Attribute',
       scope: ['meta.tag', 'meta.tag.inline.any'],
-      settings: tokens.html.attribute
+      settings: tokens.tag.attribute
+    },
+    {
+      name: 'Value',
+      scope: 'string.quoted.double.html',
+      settings: tokens.tag.value
     },
     {
       name: 'Text',

--- a/src/colors/syntax/html.colors.ts
+++ b/src/colors/syntax/html.colors.ts
@@ -23,8 +23,16 @@ const htmlColors: SyntaxColors = (tokens) => {
      */
     {
       name: 'Component tag',
-      scope: 'entity.name.tag.other',
+      scope: 'meta.tag.other.unrecognized.html.derivative entity.name.tag.html',
       settings: tokens.html.component.tag
+    },
+    {
+      name: "Component tag's punctuation",
+      scope: [
+        'meta.tag.other.html punctuation.definition.tag.begin.html',
+        'meta.tag.other.html punctuation.definition.tag.end.html'
+      ],
+      settings: tokens.html.component.punctuation
     },
     {
       name: 'Component directives',

--- a/src/colors/syntax/json.colors.ts
+++ b/src/colors/syntax/json.colors.ts
@@ -3,15 +3,6 @@ import { SyntaxColors } from '../../types/colors-types';
 const jsonColors: SyntaxColors = (tokens) => {
   return [
     /**
-     * Scalars
-     */
-    {
-      name: 'Language constant (boolean, null)',
-      scope: 'constant.language.json',
-      settings: tokens.type.constant.languageAlt
-    },
-
-    /**
      * Properties
      */
     {

--- a/src/colors/syntax/jsx.colors.ts
+++ b/src/colors/syntax/jsx.colors.ts
@@ -5,7 +5,7 @@ const jsxColors: SyntaxColors = (tokens) => {
     {
       name: 'JSX: Tag angle brackets',
       scope: 'punctuation.definition.tag.jsx',
-      settings: tokens.tag.name
+      settings: tokens.tag.punctuation
     },
     {
       name: 'JSX: Component tag',

--- a/src/colors/syntax/jsx.colors.ts
+++ b/src/colors/syntax/jsx.colors.ts
@@ -5,7 +5,7 @@ const jsxColors: SyntaxColors = (tokens) => {
     {
       name: 'JSX: Tag angle brackets',
       scope: 'punctuation.definition.tag.jsx',
-      settings: tokens.html.tag
+      settings: tokens.tag.name
     },
     {
       name: 'JSX: Component tag',
@@ -20,7 +20,13 @@ const jsxColors: SyntaxColors = (tokens) => {
       name: 'JSX: Attribute',
       scope: 'entity.other.attribute-name.jsx',
       // Pink is used in variables and method arguments
-      settings: tokens.html.attribute
+      settings: tokens.tag.attribute
+    },
+    {
+      name: 'JSX: Value',
+      scope: 'JSXAttrs string.quoted.double.js',
+      // Pink is used in variables and method arguments
+      settings: tokens.tag.value
     },
     {
       name: 'JSX: Text',

--- a/src/colors/syntax/pug.colors.ts
+++ b/src/colors/syntax/pug.colors.ts
@@ -8,7 +8,7 @@ const pugColors: SyntaxColors = (tokens) => {
     {
       name: 'Constant',
       scope: 'constant',
-      settings: tokens.html.tag
+      settings: tokens.tag.name
     },
 
     /**

--- a/src/colors/syntax/ts.colors.ts
+++ b/src/colors/syntax/ts.colors.ts
@@ -3,6 +3,15 @@ import { SyntaxColors } from '../../types/colors-types';
 const tsColors: SyntaxColors = (tokens) => {
   return [
     /**
+     * Classes
+     */
+    {
+      name: 'Typescript: Class',
+      scope: ['new.expr.ts entity.name.type.ts'],
+      settings: tokens.class.name
+    },
+
+    /**
      * Keywords
      */
     {

--- a/src/colors/syntax/yml.colors.ts
+++ b/src/colors/syntax/yml.colors.ts
@@ -3,15 +3,6 @@ import { SyntaxColors } from '../../types/colors-types';
 const ymlColors: SyntaxColors = (tokens) => {
   return [
     /**
-     * Scalars
-     */
-    {
-      name: 'Language constant (boolean, null)',
-      scope: ['constant.language.boolean.yaml', 'constant.language.null.yaml'],
-      settings: tokens.type.constant.languageAlt
-    },
-
-    /**
      * Properties
      */
     {

--- a/src/colors/syntax/yml.colors.ts
+++ b/src/colors/syntax/yml.colors.ts
@@ -9,6 +9,12 @@ const ymlColors: SyntaxColors = (tokens) => {
       name: 'Property name',
       scope: 'entity.name.tag.yaml',
       settings: tokens.tag.name
+    },
+
+    {
+      name: 'YAML: Constant',
+      scope: ['constant.language.boolean.yaml', 'constant.language.null.yaml'],
+      settings: tokens.yaml.constant
     }
   ];
 };

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -274,11 +274,14 @@ const css: Css = {
  * Tags
  */
 const tag: Tag = {
+  name: {
+    foreground: cyan[4]
+  },
   attribute: {
     foreground: blue[4]
   },
-  name: {
-    foreground: deepPurple[4]
+  value: {
+    foreground: green[4]
   }
 };
 
@@ -286,15 +289,13 @@ const tag: Tag = {
  * HTML
  */
 const html: Html = {
-  tag: tag.name,
-  attribute: tag.attribute,
   component: {
     tag: {
       foreground: orange[4]
     }
   },
   directive: {
-    foreground: orange[4]
+    foreground: red[4]
   }
 };
 

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -136,15 +136,17 @@ const functionType: FunctionType = {
 /**
  * Classes
  */
+const classForeground: string = yellow[4];
+
 const classType: ClassType = {
   name: {
-    foreground: blue[4]
+    foreground: classForeground
   },
   baseClass: {
-    foreground: blue[4]
+    foreground: classForeground
   },
   library: {
-    foreground: blue[4]
+    foreground: classForeground
   }
 };
 

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -30,12 +30,15 @@ const {
   deepPurple,
   red,
   cyan,
-  yellow
+  yellow,
+  teal
 } = universePalette;
 
 /**
  * Data types
  */
+const constantForeground: string = teal[4];
+
 const type: Type = {
   character: {
     default: {
@@ -56,13 +59,10 @@ const type: Type = {
   },
   constant: {
     language: {
-      foreground: deepPurple[4]
-    },
-    languageAlt: {
-      foreground: blue[4]
+      foreground: constantForeground
     },
     library: {
-      foreground: deepPurple[4]
+      foreground: constantForeground
     }
   },
   string: {

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -277,6 +277,9 @@ const tag: Tag = {
   name: {
     foreground: cyan[4]
   },
+  punctuation: {
+    foreground: cyan[5]
+  },
   attribute: {
     foreground: blue[4]
   },
@@ -292,6 +295,9 @@ const html: Html = {
   component: {
     tag: {
       foreground: orange[4]
+    },
+    punctuation: {
+      foreground: orange[5]
     }
   },
   directive: {

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -256,12 +256,8 @@ const css: Css = {
     foreground: orange[4]
   },
   attribute: tag.attribute,
-  pseudoClass: {
-    foreground: cyan[4]
-  },
-  pseudoElement: {
-    foreground: cyan[4]
-  },
+  pseudoClass: keyword.modifier,
+  pseudoElement: keyword.modifier,
 
   // Properties
   property: {

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -18,6 +18,7 @@ import {
   Tokens,
   Type,
   Variable,
+  Yaml,
 } from '../../types/tokens-types';
 import { universePalette } from './palette';
 
@@ -371,6 +372,15 @@ const markdown: Markdown = {
   }
 };
 
+/**
+ * YAML
+ */
+const yaml: Yaml = {
+  constant: {
+    foreground: deepPurple[4]
+  }
+};
+
 export const tokens: Tokens = {
   type,
   keyword,
@@ -390,5 +400,6 @@ export const tokens: Tokens = {
   json,
   tag,
   markup,
-  markdown
+  markdown,
+  yaml
 };

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -37,6 +37,7 @@ const {
 /**
  * Data types
  */
+const typeForeground: string = cyan[4];
 const constantForeground: string = teal[4];
 
 const type: Type = {
@@ -49,7 +50,7 @@ const type: Type = {
     }
   },
   custom: {
-    foreground: cyan[4]
+    foreground: typeForeground
   },
   number: {
     foreground: orange[4]
@@ -72,7 +73,7 @@ const type: Type = {
     foreground: deepPurple[4]
   },
   library: {
-    foreground: deepPurple[4]
+    foreground: typeForeground
   }
 };
 

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -56,7 +56,7 @@ const type: Type = {
     foreground: orange[4]
   },
   other: {
-    foreground: deepPurple[4]
+    foreground: constantForeground
   },
   constant: {
     language: {

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -114,7 +114,7 @@ const variable: Variable = {
  */
 const object: ObjectType = {
   property: {
-    foreground: blue[4]
+    foreground: green[4]
   }
 };
 

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -255,9 +255,7 @@ const css: Css = {
   class: {
     foreground: orange[4]
   },
-  attribute: {
-    foreground: deepPurple[4]
-  },
+  attribute: tag.attribute,
   pseudoClass: {
     foreground: cyan[4]
   },

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -265,9 +265,7 @@ const css: Css = {
 
   // Properties
   property: {
-    name: {
-      foreground: deepPurple[4]
-    },
+    name: object.property,
     value: {
       foreground: green[4]
     }

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -226,13 +226,29 @@ const config: Config = {
 };
 
 /**
+ * Tags
+ */
+const tag: Tag = {
+  name: {
+    foreground: cyan[4]
+  },
+  punctuation: {
+    foreground: cyan[5]
+  },
+  attribute: {
+    foreground: blue[4]
+  },
+  value: {
+    foreground: green[4]
+  }
+};
+
+/**
  * CSS
  */
 const css: Css = {
   // Selectors
-  tag: {
-    foreground: pink[4]
-  },
+  tag: tag.name,
   id: {
     foreground: yellow[4]
   },
@@ -267,24 +283,6 @@ const css: Css = {
 
   unit: {
     foreground: pink[4]
-  }
-};
-
-/**
- * Tags
- */
-const tag: Tag = {
-  name: {
-    foreground: cyan[4]
-  },
-  punctuation: {
-    foreground: cyan[5]
-  },
-  attribute: {
-    foreground: blue[4]
-  },
-  value: {
-    foreground: green[4]
   }
 };
 

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -43,7 +43,7 @@ const constantForeground: string = teal[4];
 const type: Type = {
   character: {
     default: {
-      foreground: pink[4]
+      foreground: blue[4]
     },
     escape: {
       foreground: deepPurple[4]

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -201,7 +201,7 @@ const invalid: Invalid = {
  * Comments
  */
 const comment: Settings = {
-  foreground: neutral[3]
+  foreground: neutral[5]
 };
 
 /**

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -273,8 +273,12 @@ const css: Css = {
     }
   },
 
+  number: {
+    foreground: orange[3]
+  },
+
   unit: {
-    foreground: pink[4]
+    foreground: orange[4]
   }
 };
 

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -267,7 +267,7 @@ const css: Css = {
   property: {
     name: object.property,
     value: {
-      foreground: green[4]
+      foreground: blue[4]
     }
   },
 

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -10,7 +10,6 @@ export interface Type {
   };
   constant: {
     language: Settings; // constant.language
-    languageAlt: Settings;
     library: Settings; // support.constant
   };
   custom: Settings; // entity.name.type

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -67,6 +67,7 @@ export interface Tag {
   name: Settings; // entity.name.tag
   attribute: Settings; // entity.other.attribute-name
   value: Settings;
+  punctuation: Settings;
 }
 
 // Markup
@@ -134,6 +135,7 @@ export interface Css {
 export interface Html {
   component: {
     tag: Settings;
+    punctuation: Settings;
   };
   directive: Settings;
 }

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -158,6 +158,11 @@ export interface Markdown {
   linkTitle: Settings;
 }
 
+// YAML
+export interface Yaml {
+  constant: Settings;
+}
+
 export interface Tokens {
   type: Type;
   keyword: Keyword;
@@ -178,6 +183,7 @@ export interface Tokens {
   html: Html;
   json: Json;
   markdown: Markdown;
+  yaml: Yaml;
 }
 
 export interface Settings {

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -66,6 +66,7 @@ export interface Section {
 export interface Tag {
   name: Settings; // entity.name.tag
   attribute: Settings; // entity.other.attribute-name
+  value: Settings;
 }
 
 // Markup
@@ -131,8 +132,6 @@ export interface Css {
 
 // HTML
 export interface Html {
-  tag: Settings;
-  attribute: Settings;
   component: {
     tag: Settings;
   };

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -128,6 +128,7 @@ export interface Css {
     parameter: Settings;
   };
 
+  number: Settings;
   unit: Settings;
 }
 

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -558,7 +558,7 @@
     {
       "name": "Property value",
       "scope": "meta.property-value.css",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#9AC6F2" }
     },
     {
       "name": "Function parameter",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -430,7 +430,7 @@
     {
       "name": "Library type",
       "scope": "support.type",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "Language constant (boolean, null)",
@@ -754,6 +754,11 @@
       "name": "Text",
       "scope": "text.pug",
       "settings": { "foreground": "#F2F2F2" }
+    },
+    {
+      "name": "Typescript: Class",
+      "scope": ["new.expr.ts entity.name.type.ts"],
+      "settings": { "foreground": "#E6D791" }
     },
     {
       "name": "JSON object",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -797,6 +797,14 @@
       "name": "Property name",
       "scope": "entity.name.tag.yaml",
       "settings": { "foreground": "#92D8E6" }
+    },
+    {
+      "name": "YAML: Constant",
+      "scope": [
+        "constant.language.boolean.yaml",
+        "constant.language.null.yaml"
+      ],
+      "settings": { "foreground": "#C1A2FF" }
     }
   ]
 }

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -364,7 +364,7 @@
     {
       "name": "Object property",
       "scope": ["meta.object-literal.key", "variable.object.property"],
-      "settings": { "foreground": "#9AC6F2" }
+      "settings": { "foreground": "#BBD99E" }
     },
     {
       "name": "Function definition",
@@ -597,7 +597,7 @@
     {
       "name": "Object property",
       "scope": "string.unquoted.js",
-      "settings": { "foreground": "#9AC6F2" }
+      "settings": { "foreground": "#BBD99E" }
     },
     {
       "name": "Language constant (boolean, null)",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -533,7 +533,7 @@
     {
       "name": "Attribute name",
       "scope": "entity.other.attribute-name.css",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#9AC6F2" }
     },
     {
       "name": "Pseudo-class",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -473,7 +473,7 @@
     {
       "name": "Comment",
       "scope": "comment",
-      "settings": { "foreground": "#A2AABB" }
+      "settings": { "foreground": "#758096" }
     },
     {
       "name": "Invalid",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -445,7 +445,7 @@
     {
       "name": "Other constant",
       "scope": ["constant.other", "support.other"],
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#89D9D2" }
     },
     {
       "name": "Custom type",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -281,7 +281,7 @@
     "gitDecoration.modifiedResourceForeground": "#9AC6F2",
     "gitDecoration.deletedResourceForeground": "#FFA2A2",
     "gitDecoration.untrackedResourceForeground": "#BBD99E",
-    "gitDecoration.ignoredResourceForeground": "#8A94A8",
+    "gitDecoration.ignoredResourceForeground": "#616C84",
     "gitDecoration.conflictingResourceForeground": "#FFA2A2",
     "gitDecoration.submoduleResourceForeground": "#8A94A8",
     "settings.headerForeground": "#D6D9E0",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -518,7 +518,7 @@
     {
       "name": "Tag",
       "scope": ["entity.name.tag.css", "meta.selector.css"],
-      "settings": { "foreground": "#FFBAD1" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "ID",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -63,7 +63,7 @@
     "activityBar.background": "#070E1B",
     "activityBar.dropBackground": "#050A14",
     "activityBar.foreground": "#616C84",
-    "activityBar.inactiveForeground": "#4E5A71",
+    "activityBar.inactiveForeground": "#3D485F",
     "activityBar.border": "#050A14",
     "activityBarBadge.background": "#E6D791",
     "activityBarBadge.foreground": "#332D0F",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -468,7 +468,7 @@
         "punctuation.definition.tag.begin",
         "punctuation.definition.tag.end"
       ],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#6EB4C2" }
     },
     {
       "name": "Comment",
@@ -587,8 +587,16 @@
     },
     {
       "name": "Component tag",
-      "scope": "entity.name.tag.other",
+      "scope": "meta.tag.other.unrecognized.html.derivative entity.name.tag.html",
       "settings": { "foreground": "#F2B09A" }
+    },
+    {
+      "name": "Component tag's punctuation",
+      "scope": [
+        "meta.tag.other.html punctuation.definition.tag.begin.html",
+        "meta.tag.other.html punctuation.definition.tag.end.html"
+      ],
+      "settings": { "foreground": "#CD8A74" }
     },
     {
       "name": "Component directives",
@@ -612,7 +620,7 @@
     {
       "name": "JSX: Tag angle brackets",
       "scope": "punctuation.definition.tag.jsx",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#6EB4C2" }
     },
     {
       "name": "JSX: Component tag",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -354,7 +354,7 @@
     {
       "name": "Library variable",
       "scope": "support.variable",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#FFBAD1" }
     },
     {
       "name": "Access to object property",
@@ -435,12 +435,12 @@
     {
       "name": "Language constant (boolean, null)",
       "scope": "constant.language",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#89D9D2" }
     },
     {
       "name": "Library constant",
       "scope": "support.constant",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#89D9D2" }
     },
     {
       "name": "Other constant",
@@ -598,11 +598,6 @@
       "name": "Object property",
       "scope": "string.unquoted.js",
       "settings": { "foreground": "#BBD99E" }
-    },
-    {
-      "name": "Language constant (boolean, null)",
-      "scope": "constant.language.json",
-      "settings": { "foreground": "#9AC6F2" }
     },
     {
       "name": "Property name",
@@ -769,14 +764,6 @@
       "name": "Vue directive",
       "scope": "meta.directive.vue",
       "settings": { "foreground": "#F2B09A" }
-    },
-    {
-      "name": "Language constant (boolean, null)",
-      "scope": [
-        "constant.language.boolean.yaml",
-        "constant.language.null.yaml"
-      ],
-      "settings": { "foreground": "#9AC6F2" }
     },
     {
       "name": "Property name",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -566,9 +566,14 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
+      "name": "CSS: Number",
+      "scope": "constant.numeric.css",
+      "settings": { "foreground": "#F6BFAD" }
+    },
+    {
       "name": "Unit",
       "scope": "keyword.other.unit",
-      "settings": { "foreground": "#FFBAD1" }
+      "settings": { "foreground": "#F2B09A" }
     },
     {
       "name": "Attribute",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -460,7 +460,7 @@
     {
       "name": "Tag",
       "scope": "entity.name.tag",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "Tag angle brackets",
@@ -468,7 +468,7 @@
         "punctuation.definition.tag.begin",
         "punctuation.definition.tag.end"
       ],
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "Comment",
@@ -576,6 +576,11 @@
       "settings": { "foreground": "#9AC6F2" }
     },
     {
+      "name": "Value",
+      "scope": "string.quoted.double.html",
+      "settings": { "foreground": "#BBD99E" }
+    },
+    {
       "name": "Text",
       "scope": "text.html.derivative",
       "settings": { "foreground": "#F2F2F2" }
@@ -592,7 +597,7 @@
         "punctuation.definition.generic.end.html",
         "meta.attribute.unrecognized"
       ],
-      "settings": { "foreground": "#F2B09A" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Object property",
@@ -607,7 +612,7 @@
     {
       "name": "JSX: Tag angle brackets",
       "scope": "punctuation.definition.tag.jsx",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "JSX: Component tag",
@@ -624,6 +629,11 @@
       "settings": { "foreground": "#9AC6F2" }
     },
     {
+      "name": "JSX: Value",
+      "scope": "JSXAttrs string.quoted.double.js",
+      "settings": { "foreground": "#BBD99E" }
+    },
+    {
       "name": "JSX: Text",
       "scope": ["JSXNested", "meta.jsx.children.tsx"],
       "settings": { "foreground": "#F2F2F2" }
@@ -636,7 +646,7 @@
         "punctuation.section.embedded.begin.tsx",
         "punctuation.section.embedded.end.tsx"
       ],
-      "settings": { "foreground": "#F2B09A" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "JSX: Punctuation",
@@ -738,7 +748,7 @@
     {
       "name": "Constant",
       "scope": "constant",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "Pug ID",
@@ -768,12 +778,12 @@
     {
       "name": "Vue directive",
       "scope": "meta.directive.vue",
-      "settings": { "foreground": "#F2B09A" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Property name",
       "scope": "entity.name.tag.yaml",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     }
   ]
 }

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -403,7 +403,7 @@
     {
       "name": "Character",
       "scope": "constant.character",
-      "settings": { "foreground": "#FFBAD1" }
+      "settings": { "foreground": "#9AC6F2" }
     },
     {
       "name": "Escape character",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -548,12 +548,12 @@
     {
       "name": "Property name",
       "scope": "support.type.property-name.css",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#BBD99E" }
     },
     {
       "name": "Vendor property name",
       "scope": "support.type.vendored.property-name.css",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#BBD99E" }
     },
     {
       "name": "Property value",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -538,12 +538,12 @@
     {
       "name": "Pseudo-class",
       "scope": "entity.other.attribute-name.pseudo-class.css",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#C1A2FF" }
     },
     {
       "name": "Pseudo-element",
       "scope": "entity.other.attribute-name.pseudo-element.css",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#C1A2FF" }
     },
     {
       "name": "Property name",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -388,17 +388,17 @@
         "entity.name.type.class",
         "entity.other.inherited-class"
       ],
-      "settings": { "foreground": "#9AC6F2" }
+      "settings": { "foreground": "#E6D791" }
     },
     {
       "name": "Instance",
       "scope": ["entity.name.type.instance", "variable.other.class"],
-      "settings": { "foreground": "#9AC6F2" }
+      "settings": { "foreground": "#E6D791" }
     },
     {
       "name": "Library class",
       "scope": "support.class",
-      "settings": { "foreground": "#9AC6F2" }
+      "settings": { "foreground": "#E6D791" }
     },
     {
       "name": "Character",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -558,7 +558,7 @@
     {
       "name": "Property value",
       "scope": "meta.property-value.css",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#9AC6F2" }
     },
     {
       "name": "Function parameter",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -281,7 +281,7 @@
     "gitDecoration.modifiedResourceForeground": "#9AC6F2",
     "gitDecoration.deletedResourceForeground": "#FFA2A2",
     "gitDecoration.untrackedResourceForeground": "#BBD99E",
-    "gitDecoration.ignoredResourceForeground": "#928AA8",
+    "gitDecoration.ignoredResourceForeground": "#6A6084",
     "gitDecoration.conflictingResourceForeground": "#FFA2A2",
     "gitDecoration.submoduleResourceForeground": "#928AA8",
     "settings.headerForeground": "#D8D5DF",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -430,7 +430,7 @@
     {
       "name": "Library type",
       "scope": "support.type",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "Language constant (boolean, null)",
@@ -754,6 +754,11 @@
       "name": "Text",
       "scope": "text.pug",
       "settings": { "foreground": "#F2F2F2" }
+    },
+    {
+      "name": "Typescript: Class",
+      "scope": ["new.expr.ts entity.name.type.ts"],
+      "settings": { "foreground": "#E6D791" }
     },
     {
       "name": "JSON object",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -63,7 +63,7 @@
     "activityBar.background": "#0C071B",
     "activityBar.dropBackground": "#080514",
     "activityBar.foreground": "#6A6084",
-    "activityBar.inactiveForeground": "#574E71",
+    "activityBar.inactiveForeground": "#463D5F",
     "activityBar.border": "#080514",
     "activityBarBadge.background": "#BBD99E",
     "activityBarBadge.foreground": "#243314",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -797,6 +797,14 @@
       "name": "Property name",
       "scope": "entity.name.tag.yaml",
       "settings": { "foreground": "#92D8E6" }
+    },
+    {
+      "name": "YAML: Constant",
+      "scope": [
+        "constant.language.boolean.yaml",
+        "constant.language.null.yaml"
+      ],
+      "settings": { "foreground": "#C1A2FF" }
     }
   ]
 }

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -364,7 +364,7 @@
     {
       "name": "Object property",
       "scope": ["meta.object-literal.key", "variable.object.property"],
-      "settings": { "foreground": "#9AC6F2" }
+      "settings": { "foreground": "#BBD99E" }
     },
     {
       "name": "Function definition",
@@ -597,7 +597,7 @@
     {
       "name": "Object property",
       "scope": "string.unquoted.js",
-      "settings": { "foreground": "#9AC6F2" }
+      "settings": { "foreground": "#BBD99E" }
     },
     {
       "name": "Language constant (boolean, null)",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -533,7 +533,7 @@
     {
       "name": "Attribute name",
       "scope": "entity.other.attribute-name.css",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#9AC6F2" }
     },
     {
       "name": "Pseudo-class",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -473,7 +473,7 @@
     {
       "name": "Comment",
       "scope": "comment",
-      "settings": { "foreground": "#A2AABB" }
+      "settings": { "foreground": "#758096" }
     },
     {
       "name": "Invalid",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -445,7 +445,7 @@
     {
       "name": "Other constant",
       "scope": ["constant.other", "support.other"],
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#89D9D2" }
     },
     {
       "name": "Custom type",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -518,7 +518,7 @@
     {
       "name": "Tag",
       "scope": ["entity.name.tag.css", "meta.selector.css"],
-      "settings": { "foreground": "#FFBAD1" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "ID",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -468,7 +468,7 @@
         "punctuation.definition.tag.begin",
         "punctuation.definition.tag.end"
       ],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#6EB4C2" }
     },
     {
       "name": "Comment",
@@ -587,8 +587,16 @@
     },
     {
       "name": "Component tag",
-      "scope": "entity.name.tag.other",
+      "scope": "meta.tag.other.unrecognized.html.derivative entity.name.tag.html",
       "settings": { "foreground": "#F2B09A" }
+    },
+    {
+      "name": "Component tag's punctuation",
+      "scope": [
+        "meta.tag.other.html punctuation.definition.tag.begin.html",
+        "meta.tag.other.html punctuation.definition.tag.end.html"
+      ],
+      "settings": { "foreground": "#CD8A74" }
     },
     {
       "name": "Component directives",
@@ -612,7 +620,7 @@
     {
       "name": "JSX: Tag angle brackets",
       "scope": "punctuation.definition.tag.jsx",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#6EB4C2" }
     },
     {
       "name": "JSX: Component tag",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -354,7 +354,7 @@
     {
       "name": "Library variable",
       "scope": "support.variable",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#FFBAD1" }
     },
     {
       "name": "Access to object property",
@@ -435,12 +435,12 @@
     {
       "name": "Language constant (boolean, null)",
       "scope": "constant.language",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#89D9D2" }
     },
     {
       "name": "Library constant",
       "scope": "support.constant",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#89D9D2" }
     },
     {
       "name": "Other constant",
@@ -598,11 +598,6 @@
       "name": "Object property",
       "scope": "string.unquoted.js",
       "settings": { "foreground": "#BBD99E" }
-    },
-    {
-      "name": "Language constant (boolean, null)",
-      "scope": "constant.language.json",
-      "settings": { "foreground": "#9AC6F2" }
     },
     {
       "name": "Property name",
@@ -769,14 +764,6 @@
       "name": "Vue directive",
       "scope": "meta.directive.vue",
       "settings": { "foreground": "#F2B09A" }
-    },
-    {
-      "name": "Language constant (boolean, null)",
-      "scope": [
-        "constant.language.boolean.yaml",
-        "constant.language.null.yaml"
-      ],
-      "settings": { "foreground": "#9AC6F2" }
     },
     {
       "name": "Property name",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -566,9 +566,14 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
+      "name": "CSS: Number",
+      "scope": "constant.numeric.css",
+      "settings": { "foreground": "#F6BFAD" }
+    },
+    {
       "name": "Unit",
       "scope": "keyword.other.unit",
-      "settings": { "foreground": "#FFBAD1" }
+      "settings": { "foreground": "#F2B09A" }
     },
     {
       "name": "Attribute",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -460,7 +460,7 @@
     {
       "name": "Tag",
       "scope": "entity.name.tag",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "Tag angle brackets",
@@ -468,7 +468,7 @@
         "punctuation.definition.tag.begin",
         "punctuation.definition.tag.end"
       ],
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "Comment",
@@ -576,6 +576,11 @@
       "settings": { "foreground": "#9AC6F2" }
     },
     {
+      "name": "Value",
+      "scope": "string.quoted.double.html",
+      "settings": { "foreground": "#BBD99E" }
+    },
+    {
       "name": "Text",
       "scope": "text.html.derivative",
       "settings": { "foreground": "#F2F2F2" }
@@ -592,7 +597,7 @@
         "punctuation.definition.generic.end.html",
         "meta.attribute.unrecognized"
       ],
-      "settings": { "foreground": "#F2B09A" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Object property",
@@ -607,7 +612,7 @@
     {
       "name": "JSX: Tag angle brackets",
       "scope": "punctuation.definition.tag.jsx",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "JSX: Component tag",
@@ -624,6 +629,11 @@
       "settings": { "foreground": "#9AC6F2" }
     },
     {
+      "name": "JSX: Value",
+      "scope": "JSXAttrs string.quoted.double.js",
+      "settings": { "foreground": "#BBD99E" }
+    },
+    {
       "name": "JSX: Text",
       "scope": ["JSXNested", "meta.jsx.children.tsx"],
       "settings": { "foreground": "#F2F2F2" }
@@ -636,7 +646,7 @@
         "punctuation.section.embedded.begin.tsx",
         "punctuation.section.embedded.end.tsx"
       ],
-      "settings": { "foreground": "#F2B09A" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "JSX: Punctuation",
@@ -738,7 +748,7 @@
     {
       "name": "Constant",
       "scope": "constant",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     },
     {
       "name": "Pug ID",
@@ -768,12 +778,12 @@
     {
       "name": "Vue directive",
       "scope": "meta.directive.vue",
-      "settings": { "foreground": "#F2B09A" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Property name",
       "scope": "entity.name.tag.yaml",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#92D8E6" }
     }
   ]
 }

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -403,7 +403,7 @@
     {
       "name": "Character",
       "scope": "constant.character",
-      "settings": { "foreground": "#FFBAD1" }
+      "settings": { "foreground": "#9AC6F2" }
     },
     {
       "name": "Escape character",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -548,12 +548,12 @@
     {
       "name": "Property name",
       "scope": "support.type.property-name.css",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#BBD99E" }
     },
     {
       "name": "Vendor property name",
       "scope": "support.type.vendored.property-name.css",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#BBD99E" }
     },
     {
       "name": "Property value",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -538,12 +538,12 @@
     {
       "name": "Pseudo-class",
       "scope": "entity.other.attribute-name.pseudo-class.css",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#C1A2FF" }
     },
     {
       "name": "Pseudo-element",
       "scope": "entity.other.attribute-name.pseudo-element.css",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#C1A2FF" }
     },
     {
       "name": "Property name",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -388,17 +388,17 @@
         "entity.name.type.class",
         "entity.other.inherited-class"
       ],
-      "settings": { "foreground": "#9AC6F2" }
+      "settings": { "foreground": "#E6D791" }
     },
     {
       "name": "Instance",
       "scope": ["entity.name.type.instance", "variable.other.class"],
-      "settings": { "foreground": "#9AC6F2" }
+      "settings": { "foreground": "#E6D791" }
     },
     {
       "name": "Library class",
       "scope": "support.class",
-      "settings": { "foreground": "#9AC6F2" }
+      "settings": { "foreground": "#E6D791" }
     },
     {
       "name": "Character",


### PR DESCRIPTION
## Public

### Changed

#### Common
- Use teal for language constants and other constants
- Use cyan in native types
- Use blue in special characters

#### CSS
- Use HTML tag color in the tag selector
- Use HTML attribute color in attribute selector
- Use object property color in the property name
- Use blue in property value
- Use modifier color in pseudo classes and pseudo elements
- Use orange in numbers and units

#### HTML
- Use cyan in HTML tags
- Use red color in directives (Vue, Angular)
- Use same color in tag punctuation

#### YAML
- Use deep purple in constants

### Fixed
- Make comments have less contrast
- Use yellow in classes names: use a color that differentiates them from functions and methods
- Use green in object properties

---

## Private

### Changed
- Revert: Use foreground swatch in all git colors 
- Revert: Make the activity bar's foreground darker