### PR TITLE
feat: syntax highlighting consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Syntax highlight
+
+#### Changed
+
+- Use darker grey in punctuation marks. They are less relevant than the rest of the code, this change prevents them from standing out
+- Use neutral for object property instead of the strings' green
+- Use darker color for text
+
+#### Fixed
+- Use object property color (neutral) for native objects properties
+
+#### Javascript
+- Use same color when defining or accessing an object property
+
 ## [1.6.2] 2020-03-11
 
 ### Docs

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -65,7 +65,12 @@ const commonColors: SyntaxColors = (tokens) => {
      */
     {
       name: 'Object property',
-      scope: ['meta.object-literal.key', 'variable.object.property', 'variable.other.property'],
+      scope: [
+        'meta.object-literal.key',
+        'variable.object.property',
+        'support.variable.property',
+        'variable.other.property'
+      ],
       settings: tokens.object.property
     },
 
@@ -184,14 +189,14 @@ const commonColors: SyntaxColors = (tokens) => {
       scope: 'entity.name.tag',
       settings: tokens.tag.name
     },
-    { 
-      name: 'Tag angle brackets', 
-      scope: [ 
-        'punctuation.definition.tag.begin', 
-        'punctuation.definition.tag.end' 
-      ], 
-      settings: tokens.tag.punctuation 
-    }, 
+    {
+      name: 'Tag angle brackets',
+      scope: [
+        'punctuation.definition.tag.begin',
+        'punctuation.definition.tag.end'
+      ],
+      settings: tokens.tag.punctuation
+    },
 
     /**
      * Comments

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -64,13 +64,8 @@ const commonColors: SyntaxColors = (tokens) => {
      * Objects
      */
     {
-      name: 'Access to object property',
-      scope: 'variable.other.property',
-      settings: tokens.variable.default
-    },
-    {
       name: 'Object property',
-      scope: ['meta.object-literal.key', 'variable.object.property'],
+      scope: ['meta.object-literal.key', 'variable.object.property', 'variable.other.property'],
       settings: tokens.object.property
     },
 

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -189,21 +189,21 @@ const commonColors: SyntaxColors = (tokens) => {
       scope: 'entity.name.tag',
       settings: tokens.tag.name
     },
-    {
-      name: 'Tag angle brackets',
-      scope: [
-        'punctuation.definition.tag.begin',
-        'punctuation.definition.tag.end'
-      ],
-      settings: tokens.tag.punctuation
-    },
+    { 
+      name: 'Tag angle brackets', 
+      scope: [ 
+        'punctuation.definition.tag.begin', 
+        'punctuation.definition.tag.end' 
+      ], 
+      settings: tokens.tag.punctuation 
+    }, 
 
     /**
      * Comments
      */
     {
       name: 'Comment',
-      scope: 'comment',
+      scope: ['comment', 'punctuation.definition.comment'],
       settings: tokens.comment
     },
 
@@ -222,17 +222,12 @@ const commonColors: SyntaxColors = (tokens) => {
     },
 
     /**
-     * Punctuation
+     * Punctuation marks
      */
     {
-      name: 'Symbols',
+      name: 'Punctuation marks',
       scope: 'punctuation',
       settings: tokens.punctuation.default
-    },
-    {
-      name: 'Punctuation for embedded section (eg: interpolated strings)',
-      scope: 'punctuation.section.embedded',
-      settings: tokens.punctuation.embedded
     }
   ];
 };

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -227,12 +227,12 @@ const commonColors: SyntaxColors = (tokens) => {
     {
       name: 'Symbols',
       scope: 'punctuation',
-      settings: tokens.puntuaction.default
+      settings: tokens.punctuation.default
     },
     {
       name: 'Punctuation for embedded section (eg: interpolated strings)',
       scope: 'punctuation.section.embedded',
-      settings: tokens.puntuaction.embedded
+      settings: tokens.punctuation.embedded
     }
   ];
 };

--- a/src/colors/syntax/config.colors.ts
+++ b/src/colors/syntax/config.colors.ts
@@ -20,11 +20,6 @@ const configColors: SyntaxColors = (tokens) => {
       name: 'Value',
       scope: 'source.ini',
       settings: tokens.config.value
-    },
-    {
-      name: 'Separator',
-      scope: 'punctuation.separator.key-value.ini',
-      settings: tokens.config.separator
     }
   ];
 };

--- a/src/colors/syntax/css.colors.ts
+++ b/src/colors/syntax/css.colors.ts
@@ -26,14 +26,6 @@ const cssColors: SyntaxColors = (tokens) => {
       settings: tokens.css.attribute.name
     },
     {
-      name: 'Attribute punctuation. []',
-      scope: [
-        'punctuation.definition.entity.begin.bracket.square.css',
-        'punctuation.definition.entity.end.bracket.square.css'
-      ],
-      settings: tokens.css.attribute.punctuation
-    },
-    {
       name: 'Pseudo-class',
       scope: 'entity.other.attribute-name.pseudo-class.css',
       settings: tokens.css.pseudoClass

--- a/src/colors/syntax/html.colors.ts
+++ b/src/colors/syntax/html.colors.ts
@@ -32,25 +32,9 @@ const htmlColors: SyntaxColors = (tokens) => {
       settings: tokens.html.component.tag
     },
     {
-      name: "Component tag's punctuation",
-      scope: [
-        'meta.tag.other.html punctuation.definition.tag.begin.html',
-        'meta.tag.other.html punctuation.definition.tag.end.html'
-      ],
-      settings: tokens.html.component.punctuation
-    },
-    {
       name: 'Component directives',
       scope: 'meta.attribute.unrecognized',
       settings: tokens.html.directive
-    },
-    {
-      name: 'Embedded expression punctuation. {{var}}',
-      scope: [
-        'punctuation.definition.generic.begin.html',
-        'punctuation.definition.generic.end.html'
-      ],
-      settings: tokens.html.expressionPunctuation
     }
   ];
 };

--- a/src/colors/syntax/js.colors.ts
+++ b/src/colors/syntax/js.colors.ts
@@ -30,14 +30,6 @@ const jsColors: SyntaxColors = (tokens) => {
       settings: tokens.class.library
     },
     {
-      name: 'Javascript: Template expression punctuation',
-      scope: [
-        'punctuation.definition.template-expression.begin.js',
-        'punctuation.definition.template-expression.end.js'
-      ],
-      settings: tokens.punctuation.embedded
-    },
-    {
       name: 'Arrow function. =>',
       scope: 'storage.type.function.arrow.js',
       settings: tokens.javascript.arrowFunction
@@ -65,6 +57,11 @@ const jsColors: SyntaxColors = (tokens) => {
         'keyword.operator.instanceof.js'
       ],
       settings: tokens.keyword.other
+    },
+    {
+      name: 'Javascript: Punctuation marks',
+      scope: 'meta.brace',
+      settings: tokens.punctuation.default
     }
   ];
 };

--- a/src/colors/syntax/js.colors.ts
+++ b/src/colors/syntax/js.colors.ts
@@ -35,7 +35,7 @@ const jsColors: SyntaxColors = (tokens) => {
         'punctuation.definition.template-expression.begin.js',
         'punctuation.definition.template-expression.end.js'
       ],
-      settings: tokens.puntuaction.embedded
+      settings: tokens.punctuation.embedded
     },
     {
       name: 'Arrow function. =>',

--- a/src/colors/syntax/jsx.colors.ts
+++ b/src/colors/syntax/jsx.colors.ts
@@ -3,11 +3,6 @@ import { SyntaxColors } from '../../types/colors-types';
 const jsxColors: SyntaxColors = (tokens) => {
   return [
     {
-      name: 'JSX: Tag angle brackets',
-      scope: 'punctuation.definition.tag.jsx',
-      settings: tokens.tag.punctuation
-    },
-    {
       name: 'JSX: Component tag',
       scope: [
         'support.class.component.js.jsx',
@@ -35,26 +30,6 @@ const jsxColors: SyntaxColors = (tokens) => {
     {
       name: 'JSX: Text',
       scope: ['meta.jsx.children.js.jsx', 'JSXNested', 'meta.jsx.children.tsx'],
-      settings: tokens.text
-    },
-    {
-      name: 'JSX: Expression punctuation',
-      scope: [
-        // {
-        'punctuation.section.embedded.begin.js.jsx',
-        'punctuation.section.embedded.begin.jsx',
-        'punctuation.section.embedded.begin.tsx',
-
-        // }
-        'punctuation.section.embedded.end.js.jsx',
-        'punctuation.section.embedded.end.jsx',
-        'punctuation.section.embedded.end.tsx'
-      ],
-      settings: tokens.html.expressionPunctuation
-    },
-    {
-      name: 'JSX: Punctuation',
-      scope: ['meta.brace.curly.js', 'meta.brace.round.js'],
       settings: tokens.text
     }
   ];

--- a/src/colors/syntax/md.colors.ts
+++ b/src/colors/syntax/md.colors.ts
@@ -8,7 +8,7 @@ const mdColors: SyntaxColors = (tokens) => {
     {
       name: 'MD: Heading punctuation (# title)',
       scope: 'punctuation.definition.heading.markdown',
-      settings: tokens.markdown.puntuaction.heading
+      settings: tokens.markdown.punctuation.heading
     },
 
     /**
@@ -26,21 +26,21 @@ const mdColors: SyntaxColors = (tokens) => {
     {
       name: 'MD: Bold puntuation (**text**)',
       scope: 'punctuation.definition.bold.markdown',
-      settings: tokens.markdown.puntuaction.bold
+      settings: tokens.markdown.punctuation.bold
     },
     {
       name: 'MD: Italic puntuation (__text__)',
       scope: 'punctuation.definition.italic.markdown',
-      settings: tokens.markdown.puntuaction.italic
+      settings: tokens.markdown.punctuation.italic
     },
 
     /**
      * Quote
      */
     {
-      name: 'MD: Quote puntuaction (> text)',
+      name: 'MD: Quote punctuation (> text)',
       scope: 'punctuation.definition.quote.begin.markdown',
-      settings: tokens.markdown.puntuaction.quote
+      settings: tokens.markdown.punctuation.quote
     },
 
     /**
@@ -62,7 +62,7 @@ const mdColors: SyntaxColors = (tokens) => {
         'punctuation.definition.string.end.markdown',
         'punctuation.definition.metadata.markdown'
       ],
-      settings: tokens.markdown.link.puntuaction
+      settings: tokens.markdown.link.punctuation
     },
 
     /**
@@ -80,7 +80,7 @@ const mdColors: SyntaxColors = (tokens) => {
     {
       name: 'MD: List puntuation',
       scope: 'punctuation.definition.list.begin.markdown',
-      settings: tokens.markdown.puntuaction.list
+      settings: tokens.markdown.punctuation.list
     },
 
     /**
@@ -89,7 +89,7 @@ const mdColors: SyntaxColors = (tokens) => {
     {
       name: 'MD: Separator',
       scope: 'meta.separator.markdown',
-      settings: tokens.markdown.puntuaction.separator
+      settings: tokens.markdown.punctuation.separator
     }
   ];
 };

--- a/src/colors/syntax/md.colors.ts
+++ b/src/colors/syntax/md.colors.ts
@@ -3,44 +3,12 @@ import { SyntaxColors } from '../../types/colors-types';
 const mdColors: SyntaxColors = (tokens) => {
   return [
     /**
-     * Heading
-     */
-    {
-      name: 'MD: Heading punctuation (# title)',
-      scope: 'punctuation.definition.heading.markdown',
-      settings: tokens.markdown.punctuation.heading
-    },
-
-    /**
      * Text
      */
     {
       name: 'MD: Paragraph',
       scope: 'meta.paragraph.markdown',
       settings: tokens.markup.other
-    },
-
-    /**
-     * Style
-     */
-    {
-      name: 'MD: Bold puntuation (**text**)',
-      scope: 'punctuation.definition.bold.markdown',
-      settings: tokens.markdown.punctuation.bold
-    },
-    {
-      name: 'MD: Italic puntuation (__text__)',
-      scope: 'punctuation.definition.italic.markdown',
-      settings: tokens.markdown.punctuation.italic
-    },
-
-    /**
-     * Quote
-     */
-    {
-      name: 'MD: Quote punctuation (> text)',
-      scope: 'punctuation.definition.quote.begin.markdown',
-      settings: tokens.markdown.punctuation.quote
     },
 
     /**
@@ -54,16 +22,6 @@ const mdColors: SyntaxColors = (tokens) => {
       ],
       settings: tokens.markdown.link.title
     },
-    {
-      name: 'MD: Link punctuation',
-      scope: [
-        'punctuation.definition.link.markdown',
-        'punctuation.definition.string.begin.markdown',
-        'punctuation.definition.string.end.markdown',
-        'punctuation.definition.metadata.markdown'
-      ],
-      settings: tokens.markdown.link.punctuation
-    },
 
     /**
      * Raw text (code)
@@ -72,24 +30,6 @@ const mdColors: SyntaxColors = (tokens) => {
       name: 'MD: Inline code',
       scope: 'markup.inline.raw.string.markdown',
       settings: tokens.markup.raw
-    },
-
-    /**
-     * Lists
-     */
-    {
-      name: 'MD: List puntuation',
-      scope: 'punctuation.definition.list.begin.markdown',
-      settings: tokens.markdown.punctuation.list
-    },
-
-    /**
-     * Separator
-     */
-    {
-      name: 'MD: Separator',
-      scope: 'meta.separator.markdown',
-      settings: tokens.markdown.punctuation.separator
     }
   ];
 };

--- a/src/colors/syntax/pug.colors.ts
+++ b/src/colors/syntax/pug.colors.ts
@@ -57,9 +57,9 @@ const pugColors: SyntaxColors = (tokens) => {
      * Other
      */
     {
-      name: 'Pug: String interpolation punctuaction',
+      name: 'Pug: String interpolation punctuation',
       scope: 'string.interpolated.pug',
-      settings: tokens.puntuaction.embedded
+      settings: tokens.punctuation.embedded
     },
     {
       name: 'Text',

--- a/src/colors/syntax/pug.colors.ts
+++ b/src/colors/syntax/pug.colors.ts
@@ -59,7 +59,7 @@ const pugColors: SyntaxColors = (tokens) => {
     {
       name: 'Pug: String interpolation punctuation',
       scope: 'string.interpolated.pug',
-      settings: tokens.punctuation.embedded
+      settings: tokens.punctuation.default
     },
     {
       name: 'Text',

--- a/src/colors/syntax/pug.colors.ts
+++ b/src/colors/syntax/pug.colors.ts
@@ -57,8 +57,12 @@ const pugColors: SyntaxColors = (tokens) => {
      * Other
      */
     {
-      name: 'Pug: String interpolation punctuation',
-      scope: 'string.interpolated.pug',
+      name: 'Pug: Punctuation',
+      scope: [
+        'string.interpolated.pug',
+        'constant.name.attribute.tag.pug',
+        'meta.tag.other attribute_value'
+      ],
       settings: tokens.punctuation.default
     },
     {

--- a/src/colors/syntax/ts.colors.ts
+++ b/src/colors/syntax/ts.colors.ts
@@ -36,24 +36,6 @@ const tsColors: SyntaxColors = (tokens) => {
     },
 
     {
-      name: 'Typescript: Type punctuation',
-      scope: [
-        'meta.type.tuple.ts meta.brace.square.ts',
-        'punctuation.definition.typeparameters.begin.ts',
-        'punctuation.definition.typeparameters.end.ts'
-      ],
-      settings: tokens.type.punctuation
-    },
-
-    {
-      name: 'Typescript: Template expression punctuation',
-      scope: [
-        'punctuation.definition.template-expression.begin.ts',
-        'punctuation.definition.template-expression.end.ts'
-      ],
-      settings: tokens.punctuation.embedded
-    },
-    {
       name: 'Arrow function. =>',
       scope: 'storage.type.function.arrow.ts',
       settings: tokens.javascript.arrowFunction

--- a/src/colors/syntax/ts.colors.ts
+++ b/src/colors/syntax/ts.colors.ts
@@ -51,7 +51,7 @@ const tsColors: SyntaxColors = (tokens) => {
         'punctuation.definition.template-expression.begin.ts',
         'punctuation.definition.template-expression.end.ts'
       ],
-      settings: tokens.puntuaction.embedded
+      settings: tokens.punctuation.embedded
     },
     {
       name: 'Arrow function. =>',

--- a/src/colors/syntax/yml.colors.ts
+++ b/src/colors/syntax/yml.colors.ts
@@ -12,9 +12,9 @@ const ymlColors: SyntaxColors = (tokens) => {
     },
 
     {
-      name: 'YAML: Directive puntuaction',
+      name: 'YAML: Directive punctuation',
       scope: 'punctuation.definition.directive.begin.yaml',
-      settings: tokens.yaml.directive.puntuaction
+      settings: tokens.yaml.directive.punctuation
     },
 
     {
@@ -23,18 +23,18 @@ const ymlColors: SyntaxColors = (tokens) => {
       settings: tokens.yaml.anchor.name
     },
     {
-      name: 'YAML: Anchor puntuaction',
+      name: 'YAML: Anchor punctuation',
       scope: [
         'punctuation.definition.anchor.yaml',
         'punctuation.definition.alias.yaml'
       ],
-      settings: tokens.yaml.anchor.puntuaction
+      settings: tokens.yaml.anchor.punctuation
     },
 
     {
       name: 'YAML: Sequence item punctuation',
       scope: 'punctuation.definition.block.sequence.item.yaml',
-      settings: tokens.yaml.sequence.puntuaction
+      settings: tokens.yaml.sequence.punctuation
     },
 
     {

--- a/src/colors/syntax/yml.colors.ts
+++ b/src/colors/syntax/yml.colors.ts
@@ -12,29 +12,9 @@ const ymlColors: SyntaxColors = (tokens) => {
     },
 
     {
-      name: 'YAML: Directive punctuation',
-      scope: 'punctuation.definition.directive.begin.yaml',
-      settings: tokens.yaml.directive.punctuation
-    },
-
-    {
       name: 'YAML: Anchor name',
       scope: ['entity.name.type.anchor.yaml', 'variable.other.alias.yaml'],
       settings: tokens.yaml.anchor.name
-    },
-    {
-      name: 'YAML: Anchor punctuation',
-      scope: [
-        'punctuation.definition.anchor.yaml',
-        'punctuation.definition.alias.yaml'
-      ],
-      settings: tokens.yaml.anchor.punctuation
-    },
-
-    {
-      name: 'YAML: Sequence item punctuation',
-      scope: 'punctuation.definition.block.sequence.item.yaml',
-      settings: tokens.yaml.sequence.punctuation
     },
 
     {

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -120,7 +120,7 @@ export const variable: Variable = {
  */
 export const object: ObjectType = {
   property: {
-    foreground: green[4]
+    foreground: neutral[2]
   }
 };
 

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -79,9 +79,6 @@ export const type: Type = {
   },
   library: {
     foreground: typeForeground
-  },
-  punctuation: {
-    foreground: cyan[5]
   }
 };
 
@@ -195,14 +192,12 @@ export const text: Settings = {
 };
 
 /**
- * Punctuation
+ * Punctuation marks
  */
 export const punctuation: Punctuation = {
   default: {
-    fontStyle: '' // Inherit the element color
-  },
-  embedded: {
-    foreground: deepPurple[4]
+    foreground: neutral[4],
+    fontStyle: 'normal'
   }
 };
 
@@ -237,9 +232,6 @@ export const config: Config = {
   },
   value: {
     foreground: pink[4]
-  },
-  separator: {
-    foreground: neutral[0]
   }
 };
 
@@ -250,14 +242,14 @@ export const tag: Tag = {
   name: {
     foreground: cyan[4]
   },
-  punctuation: {
-    foreground: cyan[5]
-  },
   attribute: {
     foreground: blue[4]
   },
   value: {
     foreground: green[4]
+  },
+  punctuation: {
+    foreground: cyan[5]
   }
 };
 
@@ -280,15 +272,9 @@ export const html: Html = {
   component: {
     tag: {
       foreground: orange[4]
-    },
-    punctuation: {
-      foreground: orange[5]
     }
   },
   directive: {
-    foreground: red[4]
-  },
-  expressionPunctuation: {
     foreground: red[4]
   }
 };
@@ -306,12 +292,7 @@ export const css: Css = {
     foreground: orange[4]
   },
   attribute: {
-    name: html.tag.attribute,
-
-    // use same color as html.attribute.colors
-    punctuation: {
-      foreground: blue[5]
-    }
+    name: html.tag.attribute
   },
   pseudoClass: keyword.modifier,
   pseudoElement: keyword.modifier,
@@ -399,39 +380,10 @@ export const markup: Markup = {
  * Markdown
  */
 export const markdown: Markdown = {
-  punctuation: {
-    heading: {
-      foreground: neutral[4]
-    },
-
-    // markup.bold
-    bold: {
-      foreground: green[5]
-    },
-
-    // markup.italic
-    italic: {
-      foreground: teal[5]
-    },
-
-    quote: {
-      foreground: neutral[4]
-    },
-    list: {
-      foreground: neutral[4]
-    },
-    separator: {
-      foreground: neutral[4]
-    }
-  },
-
   // markup.link
   link: {
     title: {
       foreground: blue[2]
-    },
-    punctuation: {
-      foreground: blue[5]
     }
   }
 };
@@ -451,23 +403,8 @@ export const yaml: Yaml = {
     foreground: yellow[4]
   },
 
-  directive: {
-    punctuation: {
-      foreground: deepPurple[5]
-    }
-  },
-
   anchor: {
-    name: variable.default,
-    punctuation: {
-      foreground: pink[5]
-    }
-  },
-
-  sequence: {
-    punctuation: {
-      foreground: neutral[4]
-    }
+    name: variable.default
   },
 
   constant: {

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -14,7 +14,7 @@ import {
   Markup,
   ModuleType,
   ObjectType,
-  Puntuaction,
+  Punctuation,
   Section,
   Settings,
   Sql,
@@ -195,9 +195,9 @@ export const text: Settings = {
 };
 
 /**
- * Puntuaction
+ * Punctuation
  */
-export const puntuaction: Puntuaction = {
+export const punctuation: Punctuation = {
   default: {
     fontStyle: '' // Inherit the element color
   },
@@ -399,7 +399,7 @@ export const markup: Markup = {
  * Markdown
  */
 export const markdown: Markdown = {
-  puntuaction: {
+  punctuation: {
     heading: {
       foreground: neutral[4]
     },
@@ -430,7 +430,7 @@ export const markdown: Markdown = {
     title: {
       foreground: blue[2]
     },
-    puntuaction: {
+    punctuation: {
       foreground: blue[5]
     }
   }
@@ -452,20 +452,20 @@ export const yaml: Yaml = {
   },
 
   directive: {
-    puntuaction: {
+    punctuation: {
       foreground: deepPurple[5]
     }
   },
 
   anchor: {
     name: variable.default,
-    puntuaction: {
+    punctuation: {
       foreground: pink[5]
     }
   },
 
   sequence: {
-    puntuaction: {
+    punctuation: {
       foreground: neutral[4]
     }
   },
@@ -486,7 +486,7 @@ export const tokens: Tokens = {
   module: moduleType,
   section,
   text,
-  puntuaction,
+  punctuation,
   invalid,
   comment,
   config,

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -188,7 +188,7 @@ export const section: Section = {
  * Text
  */
 export const text: Settings = {
-  foreground: neutral[0]
+  foreground: neutral[1]
 };
 
 /**

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -16,7 +16,6 @@ export interface Type {
   other: Settings; // constant.other
   typeName: Settings; // storage.type
   library: Settings; // support.type
-  punctuation: Settings;
 }
 
 // Keywords
@@ -98,7 +97,6 @@ export interface Markup {
 // Punctuation
 export interface Punctuation {
   default: Settings;
-  embedded: Settings;
 }
 
 // Invalid
@@ -112,7 +110,6 @@ export interface Config {
   groupTitle: Settings;
   key: Settings;
   value: Settings;
-  separator: Settings;
 }
 
 // CSS
@@ -123,7 +120,6 @@ export interface Css {
   class: Settings;
   attribute: {
     name: Settings;
-    punctuation: Settings;
   };
   pseudoClass: Settings;
   pseudoElement: Settings;
@@ -156,10 +152,8 @@ export interface Html {
   };
   component: {
     tag: Settings;
-    punctuation: Settings;
   };
   directive: Settings;
-  expressionPunctuation: Settings;
 }
 
 // Javascript
@@ -174,17 +168,8 @@ export interface Json {
 
 // Markdown
 export interface Markdown {
-  punctuation: {
-    heading: Settings;
-    bold: Settings;
-    italic: Settings;
-    quote: Settings;
-    list: Settings;
-    separator: Settings;
-  };
   link: {
     title: Settings;
-    punctuation: Settings;
   };
 }
 
@@ -196,15 +181,8 @@ export interface Sql {
 // YAML
 export interface Yaml {
   document: Settings;
-  directive: {
-    punctuation: Settings;
-  };
   anchor: {
     name: Settings;
-    punctuation: Settings;
-  };
-  sequence: {
-    punctuation: Settings;
   };
   constant: Settings;
 }
@@ -238,5 +216,5 @@ export interface Tokens {
 
 export interface Settings {
   foreground?: string;
-  fontStyle?: 'italic' | 'bold' | 'underline' | '';
+  fontStyle?: 'normal' | 'italic' | 'bold' | 'underline' | '';
 }

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -95,8 +95,8 @@ export interface Markup {
   other: Settings;
 }
 
-// Puntuaction
-export interface Puntuaction {
+// Punctuation
+export interface Punctuation {
   default: Settings;
   embedded: Settings;
 }
@@ -174,7 +174,7 @@ export interface Json {
 
 // Markdown
 export interface Markdown {
-  puntuaction: {
+  punctuation: {
     heading: Settings;
     bold: Settings;
     italic: Settings;
@@ -184,7 +184,7 @@ export interface Markdown {
   };
   link: {
     title: Settings;
-    puntuaction: Settings;
+    punctuation: Settings;
   };
 }
 
@@ -197,14 +197,14 @@ export interface Sql {
 export interface Yaml {
   document: Settings;
   directive: {
-    puntuaction: Settings;
+    punctuation: Settings;
   };
   anchor: {
     name: Settings;
-    puntuaction: Settings;
+    punctuation: Settings;
   };
   sequence: {
-    puntuaction: Settings;
+    punctuation: Settings;
   };
   constant: Settings;
 }
@@ -222,7 +222,7 @@ export interface Tokens {
   text: Settings;
   tag: Tag;
   markup: Markup;
-  puntuaction: Puntuaction;
+  punctuation: Punctuation;
   invalid: Invalid;
   comment: Settings;
   config: Config;

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -818,8 +818,12 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Pug: String interpolation punctuation",
-      "scope": "string.interpolated.pug",
+      "name": "Pug: Punctuation",
+      "scope": [
+        "string.interpolated.pug",
+        "constant.name.attribute.tag.pug",
+        "meta.tag.other attribute_value"
+      ],
       "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -621,7 +621,7 @@
     {
       "name": "Text",
       "scope": "text.html.derivative",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Component tag",
@@ -717,7 +717,7 @@
         "JSXNested",
         "meta.jsx.children.tsx"
       ],
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Markup: Heading",
@@ -757,17 +757,17 @@
     {
       "name": "Markup: Numbered list items",
       "scope": "markup.list.numbered",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Markup: Unnumbered list items",
       "scope": "markup.list.unnumbered",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "MD: Paragraph",
       "scope": "meta.paragraph.markdown",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "MD: Link title",
@@ -825,7 +825,7 @@
     {
       "name": "Text",
       "scope": "text.pug",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Pug: Comment",

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -362,6 +362,7 @@
       "scope": [
         "meta.object-literal.key",
         "variable.object.property",
+        "support.variable.property",
         "variable.other.property"
       ],
       "settings": { "foreground": "#BBC1CD" }

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -845,7 +845,7 @@
       "settings": { "foreground": "#68B8B1" }
     },
     {
-      "name": "MD: Quote puntuaction (> text)",
+      "name": "MD: Quote punctuation (> text)",
       "scope": "punctuation.definition.quote.begin.markdown",
       "settings": { "foreground": "#8A94A8" }
     },
@@ -918,7 +918,7 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Pug: String interpolation punctuaction",
+      "name": "Pug: String interpolation punctuation",
       "scope": "string.interpolated.pug",
       "settings": { "foreground": "#C1A2FF" }
     },
@@ -1014,7 +1014,7 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "YAML: Directive puntuaction",
+      "name": "YAML: Directive punctuation",
       "scope": "punctuation.definition.directive.begin.yaml",
       "settings": { "foreground": "#987AD6" }
     },
@@ -1024,7 +1024,7 @@
       "settings": { "foreground": "#FFBAD1" }
     },
     {
-      "name": "YAML: Anchor puntuaction",
+      "name": "YAML: Anchor punctuation",
       "scope": [
         "punctuation.definition.anchor.yaml",
         "punctuation.definition.alias.yaml"

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -473,7 +473,7 @@
     },
     {
       "name": "Comment",
-      "scope": "comment",
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": { "foreground": "#758096", "fontStyle": "italic" }
     },
     {
@@ -487,14 +487,9 @@
       "settings": { "foreground": "#FFA2A2" }
     },
     {
-      "name": "Symbols",
+      "name": "Punctuation marks",
       "scope": "punctuation",
-      "settings": { "fontStyle": "" }
-    },
-    {
-      "name": "Punctuation for embedded section (eg: interpolated strings)",
-      "scope": "punctuation.section.embedded",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {
       "name": "Group title",
@@ -510,11 +505,6 @@
       "name": "Value",
       "scope": "source.ini",
       "settings": { "foreground": "#FFBAD1" }
-    },
-    {
-      "name": "Separator",
-      "scope": "punctuation.separator.key-value.ini",
-      "settings": { "foreground": "#F2F2F2" }
     },
     {
       "name": "Tag",
@@ -535,14 +525,6 @@
       "name": "Attribute name",
       "scope": "entity.other.attribute-name.css",
       "settings": { "foreground": "#9AC6F2" }
-    },
-    {
-      "name": "Attribute punctuation. []",
-      "scope": [
-        "punctuation.definition.entity.begin.bracket.square.css",
-        "punctuation.definition.entity.end.bracket.square.css"
-      ],
-      "settings": { "foreground": "#74A0CC" }
     },
     {
       "name": "Pseudo-class",
@@ -648,25 +630,9 @@
       "settings": { "foreground": "#F2B09A" }
     },
     {
-      "name": "Component tag's punctuation",
-      "scope": [
-        "meta.tag.other.html punctuation.definition.tag.begin.html",
-        "meta.tag.other.html punctuation.definition.tag.end.html"
-      ],
-      "settings": { "foreground": "#CD8A74" }
-    },
-    {
       "name": "Component directives",
       "scope": "meta.attribute.unrecognized",
       "settings": { "foreground": "#FFA2A2", "fontStyle": "italic" }
-    },
-    {
-      "name": "Embedded expression punctuation. {{var}}",
-      "scope": [
-        "punctuation.definition.generic.begin.html",
-        "punctuation.definition.generic.end.html"
-      ],
-      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Object property",
@@ -693,14 +659,6 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "Javascript: Template expression punctuation",
-      "scope": [
-        "punctuation.definition.template-expression.begin.js",
-        "punctuation.definition.template-expression.end.js"
-      ],
-      "settings": { "foreground": "#C1A2FF" }
-    },
-    {
       "name": "Arrow function. =>",
       "scope": "storage.type.function.arrow.js",
       "settings": { "fontStyle": "" }
@@ -721,14 +679,14 @@
       "settings": { "foreground": "#C1A2FF", "fontStyle": "italic" }
     },
     {
+      "name": "Javascript: Punctuation marks",
+      "scope": "meta.brace",
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
+    },
+    {
       "name": "Property name",
       "scope": "support.type.property-name.json",
       "settings": { "foreground": "#C1A2FF" }
-    },
-    {
-      "name": "JSX: Tag angle brackets",
-      "scope": "punctuation.definition.tag.jsx",
-      "settings": { "foreground": "#6EB4C2" }
     },
     {
       "name": "JSX: Component tag",
@@ -760,23 +718,6 @@
         "JSXNested",
         "meta.jsx.children.tsx"
       ],
-      "settings": { "foreground": "#F2F2F2" }
-    },
-    {
-      "name": "JSX: Expression punctuation",
-      "scope": [
-        "punctuation.section.embedded.begin.js.jsx",
-        "punctuation.section.embedded.begin.jsx",
-        "punctuation.section.embedded.begin.tsx",
-        "punctuation.section.embedded.end.js.jsx",
-        "punctuation.section.embedded.end.jsx",
-        "punctuation.section.embedded.end.tsx"
-      ],
-      "settings": { "foreground": "#FFA2A2" }
-    },
-    {
-      "name": "JSX: Punctuation",
-      "scope": ["meta.brace.curly.js", "meta.brace.round.js"],
       "settings": { "foreground": "#F2F2F2" }
     },
     {
@@ -825,29 +766,9 @@
       "settings": { "foreground": "#F2F2F2" }
     },
     {
-      "name": "MD: Heading punctuation (# title)",
-      "scope": "punctuation.definition.heading.markdown",
-      "settings": { "foreground": "#8A94A8" }
-    },
-    {
       "name": "MD: Paragraph",
       "scope": "meta.paragraph.markdown",
       "settings": { "foreground": "#F2F2F2" }
-    },
-    {
-      "name": "MD: Bold puntuation (**text**)",
-      "scope": "punctuation.definition.bold.markdown",
-      "settings": { "foreground": "#99B87A" }
-    },
-    {
-      "name": "MD: Italic puntuation (__text__)",
-      "scope": "punctuation.definition.italic.markdown",
-      "settings": { "foreground": "#68B8B1" }
-    },
-    {
-      "name": "MD: Quote punctuation (> text)",
-      "scope": "punctuation.definition.quote.begin.markdown",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "MD: Link title",
@@ -858,29 +779,9 @@
       "settings": { "foreground": "#BFDCF9" }
     },
     {
-      "name": "MD: Link punctuation",
-      "scope": [
-        "punctuation.definition.link.markdown",
-        "punctuation.definition.string.begin.markdown",
-        "punctuation.definition.string.end.markdown",
-        "punctuation.definition.metadata.markdown"
-      ],
-      "settings": { "foreground": "#74A0CC" }
-    },
-    {
       "name": "MD: Inline code",
       "scope": "markup.inline.raw.string.markdown",
       "settings": { "foreground": "#9AC6F2" }
-    },
-    {
-      "name": "MD: List puntuation",
-      "scope": "punctuation.definition.list.begin.markdown",
-      "settings": { "foreground": "#8A94A8" }
-    },
-    {
-      "name": "MD: Separator",
-      "scope": "meta.separator.markdown",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "Constant",
@@ -920,7 +821,7 @@
     {
       "name": "Pug: String interpolation punctuation",
       "scope": "string.interpolated.pug",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {
       "name": "Text",
@@ -966,23 +867,6 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Typescript: Type punctuation",
-      "scope": [
-        "meta.type.tuple.ts meta.brace.square.ts",
-        "punctuation.definition.typeparameters.begin.ts",
-        "punctuation.definition.typeparameters.end.ts"
-      ],
-      "settings": { "foreground": "#6EB4C2" }
-    },
-    {
-      "name": "Typescript: Template expression punctuation",
-      "scope": [
-        "punctuation.definition.template-expression.begin.ts",
-        "punctuation.definition.template-expression.end.ts"
-      ],
-      "settings": { "foreground": "#C1A2FF" }
-    },
-    {
       "name": "Arrow function. =>",
       "scope": "storage.type.function.arrow.ts",
       "settings": { "fontStyle": "" }
@@ -1014,27 +898,9 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "YAML: Directive punctuation",
-      "scope": "punctuation.definition.directive.begin.yaml",
-      "settings": { "foreground": "#987AD6" }
-    },
-    {
       "name": "YAML: Anchor name",
       "scope": ["entity.name.type.anchor.yaml", "variable.other.alias.yaml"],
       "settings": { "foreground": "#FFBAD1" }
-    },
-    {
-      "name": "YAML: Anchor punctuation",
-      "scope": [
-        "punctuation.definition.anchor.yaml",
-        "punctuation.definition.alias.yaml"
-      ],
-      "settings": { "foreground": "#D68EA6" }
-    },
-    {
-      "name": "YAML: Sequence item punctuation",
-      "scope": "punctuation.definition.block.sequence.item.yaml",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "YAML: Merge key",

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -364,7 +364,7 @@
         "variable.object.property",
         "variable.other.property"
       ],
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Function definition",
@@ -541,12 +541,12 @@
         "support.type.property-name.css",
         "support.type.property-name.media.css"
       ],
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Vendor property name",
       "scope": "support.type.vendored.property-name.css",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Property value",
@@ -576,12 +576,12 @@
     {
       "name": "GraphQL: Object property",
       "scope": "meta.type.object.graphql variable.graphql",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "GraphQL: Selection set property",
       "scope": "meta.selectionset.graphql variable.graphql",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "GraphQL: Fragment",
@@ -636,7 +636,7 @@
     {
       "name": "Object property",
       "scope": "string.unquoted.js",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Javascript: Language variables",
@@ -863,7 +863,7 @@
     {
       "name": "Typescript: Enum member",
       "scope": "variable.other.enummember.ts",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Arrow function. =>",

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -358,13 +358,12 @@
       "settings": { "foreground": "#FFBAD1" }
     },
     {
-      "name": "Access to object property",
-      "scope": "variable.other.property",
-      "settings": { "foreground": "#FFBAD1" }
-    },
-    {
       "name": "Object property",
-      "scope": ["meta.object-literal.key", "variable.object.property"],
+      "scope": [
+        "meta.object-literal.key",
+        "variable.object.property",
+        "variable.other.property"
+      ],
       "settings": { "foreground": "#BBD99E" }
     },
     {

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -818,8 +818,12 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Pug: String interpolation punctuation",
-      "scope": "string.interpolated.pug",
+      "name": "Pug: Punctuation",
+      "scope": [
+        "string.interpolated.pug",
+        "constant.name.attribute.tag.pug",
+        "meta.tag.other attribute_value"
+      ],
       "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -621,7 +621,7 @@
     {
       "name": "Text",
       "scope": "text.html.derivative",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Component tag",
@@ -717,7 +717,7 @@
         "JSXNested",
         "meta.jsx.children.tsx"
       ],
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Markup: Heading",
@@ -757,17 +757,17 @@
     {
       "name": "Markup: Numbered list items",
       "scope": "markup.list.numbered",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Markup: Unnumbered list items",
       "scope": "markup.list.unnumbered",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "MD: Paragraph",
       "scope": "meta.paragraph.markdown",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "MD: Link title",
@@ -825,7 +825,7 @@
     {
       "name": "Text",
       "scope": "text.pug",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Pug: Comment",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -473,7 +473,7 @@
     },
     {
       "name": "Comment",
-      "scope": "comment",
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": { "foreground": "#758096" }
     },
     {
@@ -487,14 +487,9 @@
       "settings": { "foreground": "#FFA2A2" }
     },
     {
-      "name": "Symbols",
+      "name": "Punctuation marks",
       "scope": "punctuation",
-      "settings": { "fontStyle": "" }
-    },
-    {
-      "name": "Punctuation for embedded section (eg: interpolated strings)",
-      "scope": "punctuation.section.embedded",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {
       "name": "Group title",
@@ -510,11 +505,6 @@
       "name": "Value",
       "scope": "source.ini",
       "settings": { "foreground": "#FFBAD1" }
-    },
-    {
-      "name": "Separator",
-      "scope": "punctuation.separator.key-value.ini",
-      "settings": { "foreground": "#F2F2F2" }
     },
     {
       "name": "Tag",
@@ -535,14 +525,6 @@
       "name": "Attribute name",
       "scope": "entity.other.attribute-name.css",
       "settings": { "foreground": "#9AC6F2" }
-    },
-    {
-      "name": "Attribute punctuation. []",
-      "scope": [
-        "punctuation.definition.entity.begin.bracket.square.css",
-        "punctuation.definition.entity.end.bracket.square.css"
-      ],
-      "settings": { "foreground": "#74A0CC" }
     },
     {
       "name": "Pseudo-class",
@@ -648,24 +630,8 @@
       "settings": { "foreground": "#F2B09A" }
     },
     {
-      "name": "Component tag's punctuation",
-      "scope": [
-        "meta.tag.other.html punctuation.definition.tag.begin.html",
-        "meta.tag.other.html punctuation.definition.tag.end.html"
-      ],
-      "settings": { "foreground": "#CD8A74" }
-    },
-    {
       "name": "Component directives",
       "scope": "meta.attribute.unrecognized",
-      "settings": { "foreground": "#FFA2A2" }
-    },
-    {
-      "name": "Embedded expression punctuation. {{var}}",
-      "scope": [
-        "punctuation.definition.generic.begin.html",
-        "punctuation.definition.generic.end.html"
-      ],
       "settings": { "foreground": "#FFA2A2" }
     },
     {
@@ -693,14 +659,6 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "Javascript: Template expression punctuation",
-      "scope": [
-        "punctuation.definition.template-expression.begin.js",
-        "punctuation.definition.template-expression.end.js"
-      ],
-      "settings": { "foreground": "#C1A2FF" }
-    },
-    {
       "name": "Arrow function. =>",
       "scope": "storage.type.function.arrow.js",
       "settings": { "foreground": "#C1A2FF" }
@@ -721,14 +679,14 @@
       "settings": { "foreground": "#C1A2FF" }
     },
     {
+      "name": "Javascript: Punctuation marks",
+      "scope": "meta.brace",
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
+    },
+    {
       "name": "Property name",
       "scope": "support.type.property-name.json",
       "settings": { "foreground": "#C1A2FF" }
-    },
-    {
-      "name": "JSX: Tag angle brackets",
-      "scope": "punctuation.definition.tag.jsx",
-      "settings": { "foreground": "#6EB4C2" }
     },
     {
       "name": "JSX: Component tag",
@@ -760,23 +718,6 @@
         "JSXNested",
         "meta.jsx.children.tsx"
       ],
-      "settings": { "foreground": "#F2F2F2" }
-    },
-    {
-      "name": "JSX: Expression punctuation",
-      "scope": [
-        "punctuation.section.embedded.begin.js.jsx",
-        "punctuation.section.embedded.begin.jsx",
-        "punctuation.section.embedded.begin.tsx",
-        "punctuation.section.embedded.end.js.jsx",
-        "punctuation.section.embedded.end.jsx",
-        "punctuation.section.embedded.end.tsx"
-      ],
-      "settings": { "foreground": "#FFA2A2" }
-    },
-    {
-      "name": "JSX: Punctuation",
-      "scope": ["meta.brace.curly.js", "meta.brace.round.js"],
       "settings": { "foreground": "#F2F2F2" }
     },
     {
@@ -825,29 +766,9 @@
       "settings": { "foreground": "#F2F2F2" }
     },
     {
-      "name": "MD: Heading punctuation (# title)",
-      "scope": "punctuation.definition.heading.markdown",
-      "settings": { "foreground": "#8A94A8" }
-    },
-    {
       "name": "MD: Paragraph",
       "scope": "meta.paragraph.markdown",
       "settings": { "foreground": "#F2F2F2" }
-    },
-    {
-      "name": "MD: Bold puntuation (**text**)",
-      "scope": "punctuation.definition.bold.markdown",
-      "settings": { "foreground": "#99B87A" }
-    },
-    {
-      "name": "MD: Italic puntuation (__text__)",
-      "scope": "punctuation.definition.italic.markdown",
-      "settings": { "foreground": "#68B8B1" }
-    },
-    {
-      "name": "MD: Quote punctuation (> text)",
-      "scope": "punctuation.definition.quote.begin.markdown",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "MD: Link title",
@@ -858,29 +779,9 @@
       "settings": { "foreground": "#BFDCF9" }
     },
     {
-      "name": "MD: Link punctuation",
-      "scope": [
-        "punctuation.definition.link.markdown",
-        "punctuation.definition.string.begin.markdown",
-        "punctuation.definition.string.end.markdown",
-        "punctuation.definition.metadata.markdown"
-      ],
-      "settings": { "foreground": "#74A0CC" }
-    },
-    {
       "name": "MD: Inline code",
       "scope": "markup.inline.raw.string.markdown",
       "settings": { "foreground": "#9AC6F2" }
-    },
-    {
-      "name": "MD: List puntuation",
-      "scope": "punctuation.definition.list.begin.markdown",
-      "settings": { "foreground": "#8A94A8" }
-    },
-    {
-      "name": "MD: Separator",
-      "scope": "meta.separator.markdown",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "Constant",
@@ -920,7 +821,7 @@
     {
       "name": "Pug: String interpolation punctuation",
       "scope": "string.interpolated.pug",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {
       "name": "Text",
@@ -966,23 +867,6 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Typescript: Type punctuation",
-      "scope": [
-        "meta.type.tuple.ts meta.brace.square.ts",
-        "punctuation.definition.typeparameters.begin.ts",
-        "punctuation.definition.typeparameters.end.ts"
-      ],
-      "settings": { "foreground": "#6EB4C2" }
-    },
-    {
-      "name": "Typescript: Template expression punctuation",
-      "scope": [
-        "punctuation.definition.template-expression.begin.ts",
-        "punctuation.definition.template-expression.end.ts"
-      ],
-      "settings": { "foreground": "#C1A2FF" }
-    },
-    {
       "name": "Arrow function. =>",
       "scope": "storage.type.function.arrow.ts",
       "settings": { "foreground": "#C1A2FF" }
@@ -1014,27 +898,9 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "YAML: Directive punctuation",
-      "scope": "punctuation.definition.directive.begin.yaml",
-      "settings": { "foreground": "#987AD6" }
-    },
-    {
       "name": "YAML: Anchor name",
       "scope": ["entity.name.type.anchor.yaml", "variable.other.alias.yaml"],
       "settings": { "foreground": "#FFBAD1" }
-    },
-    {
-      "name": "YAML: Anchor punctuation",
-      "scope": [
-        "punctuation.definition.anchor.yaml",
-        "punctuation.definition.alias.yaml"
-      ],
-      "settings": { "foreground": "#D68EA6" }
-    },
-    {
-      "name": "YAML: Sequence item punctuation",
-      "scope": "punctuation.definition.block.sequence.item.yaml",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "YAML: Merge key",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -362,6 +362,7 @@
       "scope": [
         "meta.object-literal.key",
         "variable.object.property",
+        "support.variable.property",
         "variable.other.property"
       ],
       "settings": { "foreground": "#BBC1CD" }

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -845,7 +845,7 @@
       "settings": { "foreground": "#68B8B1" }
     },
     {
-      "name": "MD: Quote puntuaction (> text)",
+      "name": "MD: Quote punctuation (> text)",
       "scope": "punctuation.definition.quote.begin.markdown",
       "settings": { "foreground": "#8A94A8" }
     },
@@ -918,7 +918,7 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Pug: String interpolation punctuaction",
+      "name": "Pug: String interpolation punctuation",
       "scope": "string.interpolated.pug",
       "settings": { "foreground": "#C1A2FF" }
     },
@@ -1014,7 +1014,7 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "YAML: Directive puntuaction",
+      "name": "YAML: Directive punctuation",
       "scope": "punctuation.definition.directive.begin.yaml",
       "settings": { "foreground": "#987AD6" }
     },
@@ -1024,7 +1024,7 @@
       "settings": { "foreground": "#FFBAD1" }
     },
     {
-      "name": "YAML: Anchor puntuaction",
+      "name": "YAML: Anchor punctuation",
       "scope": [
         "punctuation.definition.anchor.yaml",
         "punctuation.definition.alias.yaml"

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -364,7 +364,7 @@
         "variable.object.property",
         "variable.other.property"
       ],
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Function definition",
@@ -541,12 +541,12 @@
         "support.type.property-name.css",
         "support.type.property-name.media.css"
       ],
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Vendor property name",
       "scope": "support.type.vendored.property-name.css",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Property value",
@@ -576,12 +576,12 @@
     {
       "name": "GraphQL: Object property",
       "scope": "meta.type.object.graphql variable.graphql",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "GraphQL: Selection set property",
       "scope": "meta.selectionset.graphql variable.graphql",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "GraphQL: Fragment",
@@ -636,7 +636,7 @@
     {
       "name": "Object property",
       "scope": "string.unquoted.js",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Javascript: Language variables",
@@ -863,7 +863,7 @@
     {
       "name": "Typescript: Enum member",
       "scope": "variable.other.enummember.ts",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Arrow function. =>",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -358,13 +358,12 @@
       "settings": { "foreground": "#FFBAD1" }
     },
     {
-      "name": "Access to object property",
-      "scope": "variable.other.property",
-      "settings": { "foreground": "#FFBAD1" }
-    },
-    {
       "name": "Object property",
-      "scope": ["meta.object-literal.key", "variable.object.property"],
+      "scope": [
+        "meta.object-literal.key",
+        "variable.object.property",
+        "variable.other.property"
+      ],
       "settings": { "foreground": "#BBD99E" }
     },
     {

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -818,8 +818,12 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Pug: String interpolation punctuation",
-      "scope": "string.interpolated.pug",
+      "name": "Pug: Punctuation",
+      "scope": [
+        "string.interpolated.pug",
+        "constant.name.attribute.tag.pug",
+        "meta.tag.other attribute_value"
+      ],
       "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -621,7 +621,7 @@
     {
       "name": "Text",
       "scope": "text.html.derivative",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Component tag",
@@ -717,7 +717,7 @@
         "JSXNested",
         "meta.jsx.children.tsx"
       ],
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Markup: Heading",
@@ -757,17 +757,17 @@
     {
       "name": "Markup: Numbered list items",
       "scope": "markup.list.numbered",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Markup: Unnumbered list items",
       "scope": "markup.list.unnumbered",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "MD: Paragraph",
       "scope": "meta.paragraph.markdown",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "MD: Link title",
@@ -825,7 +825,7 @@
     {
       "name": "Text",
       "scope": "text.pug",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Pug: Comment",

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -362,6 +362,7 @@
       "scope": [
         "meta.object-literal.key",
         "variable.object.property",
+        "support.variable.property",
         "variable.other.property"
       ],
       "settings": { "foreground": "#BBC1CD" }

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -845,7 +845,7 @@
       "settings": { "foreground": "#68B8B1" }
     },
     {
-      "name": "MD: Quote puntuaction (> text)",
+      "name": "MD: Quote punctuation (> text)",
       "scope": "punctuation.definition.quote.begin.markdown",
       "settings": { "foreground": "#8A94A8" }
     },
@@ -918,7 +918,7 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Pug: String interpolation punctuaction",
+      "name": "Pug: String interpolation punctuation",
       "scope": "string.interpolated.pug",
       "settings": { "foreground": "#C1A2FF" }
     },
@@ -1014,7 +1014,7 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "YAML: Directive puntuaction",
+      "name": "YAML: Directive punctuation",
       "scope": "punctuation.definition.directive.begin.yaml",
       "settings": { "foreground": "#987AD6" }
     },
@@ -1024,7 +1024,7 @@
       "settings": { "foreground": "#FFBAD1" }
     },
     {
-      "name": "YAML: Anchor puntuaction",
+      "name": "YAML: Anchor punctuation",
       "scope": [
         "punctuation.definition.anchor.yaml",
         "punctuation.definition.alias.yaml"

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -473,7 +473,7 @@
     },
     {
       "name": "Comment",
-      "scope": "comment",
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": { "foreground": "#758096", "fontStyle": "italic" }
     },
     {
@@ -487,14 +487,9 @@
       "settings": { "foreground": "#FFA2A2" }
     },
     {
-      "name": "Symbols",
+      "name": "Punctuation marks",
       "scope": "punctuation",
-      "settings": { "fontStyle": "" }
-    },
-    {
-      "name": "Punctuation for embedded section (eg: interpolated strings)",
-      "scope": "punctuation.section.embedded",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {
       "name": "Group title",
@@ -510,11 +505,6 @@
       "name": "Value",
       "scope": "source.ini",
       "settings": { "foreground": "#FFBAD1" }
-    },
-    {
-      "name": "Separator",
-      "scope": "punctuation.separator.key-value.ini",
-      "settings": { "foreground": "#F2F2F2" }
     },
     {
       "name": "Tag",
@@ -535,14 +525,6 @@
       "name": "Attribute name",
       "scope": "entity.other.attribute-name.css",
       "settings": { "foreground": "#9AC6F2" }
-    },
-    {
-      "name": "Attribute punctuation. []",
-      "scope": [
-        "punctuation.definition.entity.begin.bracket.square.css",
-        "punctuation.definition.entity.end.bracket.square.css"
-      ],
-      "settings": { "foreground": "#74A0CC" }
     },
     {
       "name": "Pseudo-class",
@@ -648,25 +630,9 @@
       "settings": { "foreground": "#F2B09A" }
     },
     {
-      "name": "Component tag's punctuation",
-      "scope": [
-        "meta.tag.other.html punctuation.definition.tag.begin.html",
-        "meta.tag.other.html punctuation.definition.tag.end.html"
-      ],
-      "settings": { "foreground": "#CD8A74" }
-    },
-    {
       "name": "Component directives",
       "scope": "meta.attribute.unrecognized",
       "settings": { "foreground": "#FFA2A2", "fontStyle": "italic" }
-    },
-    {
-      "name": "Embedded expression punctuation. {{var}}",
-      "scope": [
-        "punctuation.definition.generic.begin.html",
-        "punctuation.definition.generic.end.html"
-      ],
-      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Object property",
@@ -693,14 +659,6 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "Javascript: Template expression punctuation",
-      "scope": [
-        "punctuation.definition.template-expression.begin.js",
-        "punctuation.definition.template-expression.end.js"
-      ],
-      "settings": { "foreground": "#C1A2FF" }
-    },
-    {
       "name": "Arrow function. =>",
       "scope": "storage.type.function.arrow.js",
       "settings": { "fontStyle": "" }
@@ -721,14 +679,14 @@
       "settings": { "foreground": "#C1A2FF", "fontStyle": "italic" }
     },
     {
+      "name": "Javascript: Punctuation marks",
+      "scope": "meta.brace",
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
+    },
+    {
       "name": "Property name",
       "scope": "support.type.property-name.json",
       "settings": { "foreground": "#C1A2FF" }
-    },
-    {
-      "name": "JSX: Tag angle brackets",
-      "scope": "punctuation.definition.tag.jsx",
-      "settings": { "foreground": "#6EB4C2" }
     },
     {
       "name": "JSX: Component tag",
@@ -760,23 +718,6 @@
         "JSXNested",
         "meta.jsx.children.tsx"
       ],
-      "settings": { "foreground": "#F2F2F2" }
-    },
-    {
-      "name": "JSX: Expression punctuation",
-      "scope": [
-        "punctuation.section.embedded.begin.js.jsx",
-        "punctuation.section.embedded.begin.jsx",
-        "punctuation.section.embedded.begin.tsx",
-        "punctuation.section.embedded.end.js.jsx",
-        "punctuation.section.embedded.end.jsx",
-        "punctuation.section.embedded.end.tsx"
-      ],
-      "settings": { "foreground": "#FFA2A2" }
-    },
-    {
-      "name": "JSX: Punctuation",
-      "scope": ["meta.brace.curly.js", "meta.brace.round.js"],
       "settings": { "foreground": "#F2F2F2" }
     },
     {
@@ -825,29 +766,9 @@
       "settings": { "foreground": "#F2F2F2" }
     },
     {
-      "name": "MD: Heading punctuation (# title)",
-      "scope": "punctuation.definition.heading.markdown",
-      "settings": { "foreground": "#8A94A8" }
-    },
-    {
       "name": "MD: Paragraph",
       "scope": "meta.paragraph.markdown",
       "settings": { "foreground": "#F2F2F2" }
-    },
-    {
-      "name": "MD: Bold puntuation (**text**)",
-      "scope": "punctuation.definition.bold.markdown",
-      "settings": { "foreground": "#99B87A" }
-    },
-    {
-      "name": "MD: Italic puntuation (__text__)",
-      "scope": "punctuation.definition.italic.markdown",
-      "settings": { "foreground": "#68B8B1" }
-    },
-    {
-      "name": "MD: Quote punctuation (> text)",
-      "scope": "punctuation.definition.quote.begin.markdown",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "MD: Link title",
@@ -858,29 +779,9 @@
       "settings": { "foreground": "#BFDCF9" }
     },
     {
-      "name": "MD: Link punctuation",
-      "scope": [
-        "punctuation.definition.link.markdown",
-        "punctuation.definition.string.begin.markdown",
-        "punctuation.definition.string.end.markdown",
-        "punctuation.definition.metadata.markdown"
-      ],
-      "settings": { "foreground": "#74A0CC" }
-    },
-    {
       "name": "MD: Inline code",
       "scope": "markup.inline.raw.string.markdown",
       "settings": { "foreground": "#9AC6F2" }
-    },
-    {
-      "name": "MD: List puntuation",
-      "scope": "punctuation.definition.list.begin.markdown",
-      "settings": { "foreground": "#8A94A8" }
-    },
-    {
-      "name": "MD: Separator",
-      "scope": "meta.separator.markdown",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "Constant",
@@ -920,7 +821,7 @@
     {
       "name": "Pug: String interpolation punctuation",
       "scope": "string.interpolated.pug",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {
       "name": "Text",
@@ -966,23 +867,6 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Typescript: Type punctuation",
-      "scope": [
-        "meta.type.tuple.ts meta.brace.square.ts",
-        "punctuation.definition.typeparameters.begin.ts",
-        "punctuation.definition.typeparameters.end.ts"
-      ],
-      "settings": { "foreground": "#6EB4C2" }
-    },
-    {
-      "name": "Typescript: Template expression punctuation",
-      "scope": [
-        "punctuation.definition.template-expression.begin.ts",
-        "punctuation.definition.template-expression.end.ts"
-      ],
-      "settings": { "foreground": "#C1A2FF" }
-    },
-    {
       "name": "Arrow function. =>",
       "scope": "storage.type.function.arrow.ts",
       "settings": { "fontStyle": "" }
@@ -1014,27 +898,9 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "YAML: Directive punctuation",
-      "scope": "punctuation.definition.directive.begin.yaml",
-      "settings": { "foreground": "#987AD6" }
-    },
-    {
       "name": "YAML: Anchor name",
       "scope": ["entity.name.type.anchor.yaml", "variable.other.alias.yaml"],
       "settings": { "foreground": "#FFBAD1" }
-    },
-    {
-      "name": "YAML: Anchor punctuation",
-      "scope": [
-        "punctuation.definition.anchor.yaml",
-        "punctuation.definition.alias.yaml"
-      ],
-      "settings": { "foreground": "#D68EA6" }
-    },
-    {
-      "name": "YAML: Sequence item punctuation",
-      "scope": "punctuation.definition.block.sequence.item.yaml",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "YAML: Merge key",

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -364,7 +364,7 @@
         "variable.object.property",
         "variable.other.property"
       ],
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Function definition",
@@ -541,12 +541,12 @@
         "support.type.property-name.css",
         "support.type.property-name.media.css"
       ],
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Vendor property name",
       "scope": "support.type.vendored.property-name.css",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Property value",
@@ -576,12 +576,12 @@
     {
       "name": "GraphQL: Object property",
       "scope": "meta.type.object.graphql variable.graphql",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "GraphQL: Selection set property",
       "scope": "meta.selectionset.graphql variable.graphql",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "GraphQL: Fragment",
@@ -636,7 +636,7 @@
     {
       "name": "Object property",
       "scope": "string.unquoted.js",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Javascript: Language variables",
@@ -863,7 +863,7 @@
     {
       "name": "Typescript: Enum member",
       "scope": "variable.other.enummember.ts",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Arrow function. =>",

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -358,13 +358,12 @@
       "settings": { "foreground": "#FFBAD1" }
     },
     {
-      "name": "Access to object property",
-      "scope": "variable.other.property",
-      "settings": { "foreground": "#FFBAD1" }
-    },
-    {
       "name": "Object property",
-      "scope": ["meta.object-literal.key", "variable.object.property"],
+      "scope": [
+        "meta.object-literal.key",
+        "variable.object.property",
+        "variable.other.property"
+      ],
       "settings": { "foreground": "#BBD99E" }
     },
     {

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -818,8 +818,12 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Pug: String interpolation punctuation",
-      "scope": "string.interpolated.pug",
+      "name": "Pug: Punctuation",
+      "scope": [
+        "string.interpolated.pug",
+        "constant.name.attribute.tag.pug",
+        "meta.tag.other attribute_value"
+      ],
       "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -621,7 +621,7 @@
     {
       "name": "Text",
       "scope": "text.html.derivative",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Component tag",
@@ -717,7 +717,7 @@
         "JSXNested",
         "meta.jsx.children.tsx"
       ],
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Markup: Heading",
@@ -757,17 +757,17 @@
     {
       "name": "Markup: Numbered list items",
       "scope": "markup.list.numbered",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Markup: Unnumbered list items",
       "scope": "markup.list.unnumbered",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "MD: Paragraph",
       "scope": "meta.paragraph.markdown",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "MD: Link title",
@@ -825,7 +825,7 @@
     {
       "name": "Text",
       "scope": "text.pug",
-      "settings": { "foreground": "#F2F2F2" }
+      "settings": { "foreground": "#D6D9E0" }
     },
     {
       "name": "Pug: Comment",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -473,7 +473,7 @@
     },
     {
       "name": "Comment",
-      "scope": "comment",
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": { "foreground": "#758096" }
     },
     {
@@ -487,14 +487,9 @@
       "settings": { "foreground": "#FFA2A2" }
     },
     {
-      "name": "Symbols",
+      "name": "Punctuation marks",
       "scope": "punctuation",
-      "settings": { "fontStyle": "" }
-    },
-    {
-      "name": "Punctuation for embedded section (eg: interpolated strings)",
-      "scope": "punctuation.section.embedded",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {
       "name": "Group title",
@@ -510,11 +505,6 @@
       "name": "Value",
       "scope": "source.ini",
       "settings": { "foreground": "#FFBAD1" }
-    },
-    {
-      "name": "Separator",
-      "scope": "punctuation.separator.key-value.ini",
-      "settings": { "foreground": "#F2F2F2" }
     },
     {
       "name": "Tag",
@@ -535,14 +525,6 @@
       "name": "Attribute name",
       "scope": "entity.other.attribute-name.css",
       "settings": { "foreground": "#9AC6F2" }
-    },
-    {
-      "name": "Attribute punctuation. []",
-      "scope": [
-        "punctuation.definition.entity.begin.bracket.square.css",
-        "punctuation.definition.entity.end.bracket.square.css"
-      ],
-      "settings": { "foreground": "#74A0CC" }
     },
     {
       "name": "Pseudo-class",
@@ -648,24 +630,8 @@
       "settings": { "foreground": "#F2B09A" }
     },
     {
-      "name": "Component tag's punctuation",
-      "scope": [
-        "meta.tag.other.html punctuation.definition.tag.begin.html",
-        "meta.tag.other.html punctuation.definition.tag.end.html"
-      ],
-      "settings": { "foreground": "#CD8A74" }
-    },
-    {
       "name": "Component directives",
       "scope": "meta.attribute.unrecognized",
-      "settings": { "foreground": "#FFA2A2" }
-    },
-    {
-      "name": "Embedded expression punctuation. {{var}}",
-      "scope": [
-        "punctuation.definition.generic.begin.html",
-        "punctuation.definition.generic.end.html"
-      ],
       "settings": { "foreground": "#FFA2A2" }
     },
     {
@@ -693,14 +659,6 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "Javascript: Template expression punctuation",
-      "scope": [
-        "punctuation.definition.template-expression.begin.js",
-        "punctuation.definition.template-expression.end.js"
-      ],
-      "settings": { "foreground": "#C1A2FF" }
-    },
-    {
       "name": "Arrow function. =>",
       "scope": "storage.type.function.arrow.js",
       "settings": { "foreground": "#C1A2FF" }
@@ -721,14 +679,14 @@
       "settings": { "foreground": "#C1A2FF" }
     },
     {
+      "name": "Javascript: Punctuation marks",
+      "scope": "meta.brace",
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
+    },
+    {
       "name": "Property name",
       "scope": "support.type.property-name.json",
       "settings": { "foreground": "#C1A2FF" }
-    },
-    {
-      "name": "JSX: Tag angle brackets",
-      "scope": "punctuation.definition.tag.jsx",
-      "settings": { "foreground": "#6EB4C2" }
     },
     {
       "name": "JSX: Component tag",
@@ -760,23 +718,6 @@
         "JSXNested",
         "meta.jsx.children.tsx"
       ],
-      "settings": { "foreground": "#F2F2F2" }
-    },
-    {
-      "name": "JSX: Expression punctuation",
-      "scope": [
-        "punctuation.section.embedded.begin.js.jsx",
-        "punctuation.section.embedded.begin.jsx",
-        "punctuation.section.embedded.begin.tsx",
-        "punctuation.section.embedded.end.js.jsx",
-        "punctuation.section.embedded.end.jsx",
-        "punctuation.section.embedded.end.tsx"
-      ],
-      "settings": { "foreground": "#FFA2A2" }
-    },
-    {
-      "name": "JSX: Punctuation",
-      "scope": ["meta.brace.curly.js", "meta.brace.round.js"],
       "settings": { "foreground": "#F2F2F2" }
     },
     {
@@ -825,29 +766,9 @@
       "settings": { "foreground": "#F2F2F2" }
     },
     {
-      "name": "MD: Heading punctuation (# title)",
-      "scope": "punctuation.definition.heading.markdown",
-      "settings": { "foreground": "#8A94A8" }
-    },
-    {
       "name": "MD: Paragraph",
       "scope": "meta.paragraph.markdown",
       "settings": { "foreground": "#F2F2F2" }
-    },
-    {
-      "name": "MD: Bold puntuation (**text**)",
-      "scope": "punctuation.definition.bold.markdown",
-      "settings": { "foreground": "#99B87A" }
-    },
-    {
-      "name": "MD: Italic puntuation (__text__)",
-      "scope": "punctuation.definition.italic.markdown",
-      "settings": { "foreground": "#68B8B1" }
-    },
-    {
-      "name": "MD: Quote punctuation (> text)",
-      "scope": "punctuation.definition.quote.begin.markdown",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "MD: Link title",
@@ -858,29 +779,9 @@
       "settings": { "foreground": "#BFDCF9" }
     },
     {
-      "name": "MD: Link punctuation",
-      "scope": [
-        "punctuation.definition.link.markdown",
-        "punctuation.definition.string.begin.markdown",
-        "punctuation.definition.string.end.markdown",
-        "punctuation.definition.metadata.markdown"
-      ],
-      "settings": { "foreground": "#74A0CC" }
-    },
-    {
       "name": "MD: Inline code",
       "scope": "markup.inline.raw.string.markdown",
       "settings": { "foreground": "#9AC6F2" }
-    },
-    {
-      "name": "MD: List puntuation",
-      "scope": "punctuation.definition.list.begin.markdown",
-      "settings": { "foreground": "#8A94A8" }
-    },
-    {
-      "name": "MD: Separator",
-      "scope": "meta.separator.markdown",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "Constant",
@@ -920,7 +821,7 @@
     {
       "name": "Pug: String interpolation punctuation",
       "scope": "string.interpolated.pug",
-      "settings": { "foreground": "#C1A2FF" }
+      "settings": { "foreground": "#8A94A8", "fontStyle": "normal" }
     },
     {
       "name": "Text",
@@ -966,23 +867,6 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Typescript: Type punctuation",
-      "scope": [
-        "meta.type.tuple.ts meta.brace.square.ts",
-        "punctuation.definition.typeparameters.begin.ts",
-        "punctuation.definition.typeparameters.end.ts"
-      ],
-      "settings": { "foreground": "#6EB4C2" }
-    },
-    {
-      "name": "Typescript: Template expression punctuation",
-      "scope": [
-        "punctuation.definition.template-expression.begin.ts",
-        "punctuation.definition.template-expression.end.ts"
-      ],
-      "settings": { "foreground": "#C1A2FF" }
-    },
-    {
       "name": "Arrow function. =>",
       "scope": "storage.type.function.arrow.ts",
       "settings": { "foreground": "#C1A2FF" }
@@ -1014,27 +898,9 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "YAML: Directive punctuation",
-      "scope": "punctuation.definition.directive.begin.yaml",
-      "settings": { "foreground": "#987AD6" }
-    },
-    {
       "name": "YAML: Anchor name",
       "scope": ["entity.name.type.anchor.yaml", "variable.other.alias.yaml"],
       "settings": { "foreground": "#FFBAD1" }
-    },
-    {
-      "name": "YAML: Anchor punctuation",
-      "scope": [
-        "punctuation.definition.anchor.yaml",
-        "punctuation.definition.alias.yaml"
-      ],
-      "settings": { "foreground": "#D68EA6" }
-    },
-    {
-      "name": "YAML: Sequence item punctuation",
-      "scope": "punctuation.definition.block.sequence.item.yaml",
-      "settings": { "foreground": "#8A94A8" }
     },
     {
       "name": "YAML: Merge key",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -362,6 +362,7 @@
       "scope": [
         "meta.object-literal.key",
         "variable.object.property",
+        "support.variable.property",
         "variable.other.property"
       ],
       "settings": { "foreground": "#BBC1CD" }

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -845,7 +845,7 @@
       "settings": { "foreground": "#68B8B1" }
     },
     {
-      "name": "MD: Quote puntuaction (> text)",
+      "name": "MD: Quote punctuation (> text)",
       "scope": "punctuation.definition.quote.begin.markdown",
       "settings": { "foreground": "#8A94A8" }
     },
@@ -918,7 +918,7 @@
       "settings": { "foreground": "#BBD99E" }
     },
     {
-      "name": "Pug: String interpolation punctuaction",
+      "name": "Pug: String interpolation punctuation",
       "scope": "string.interpolated.pug",
       "settings": { "foreground": "#C1A2FF" }
     },
@@ -1014,7 +1014,7 @@
       "settings": { "foreground": "#E6D791" }
     },
     {
-      "name": "YAML: Directive puntuaction",
+      "name": "YAML: Directive punctuation",
       "scope": "punctuation.definition.directive.begin.yaml",
       "settings": { "foreground": "#987AD6" }
     },
@@ -1024,7 +1024,7 @@
       "settings": { "foreground": "#FFBAD1" }
     },
     {
-      "name": "YAML: Anchor puntuaction",
+      "name": "YAML: Anchor punctuation",
       "scope": [
         "punctuation.definition.anchor.yaml",
         "punctuation.definition.alias.yaml"

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -364,7 +364,7 @@
         "variable.object.property",
         "variable.other.property"
       ],
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Function definition",
@@ -541,12 +541,12 @@
         "support.type.property-name.css",
         "support.type.property-name.media.css"
       ],
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Vendor property name",
       "scope": "support.type.vendored.property-name.css",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Property value",
@@ -576,12 +576,12 @@
     {
       "name": "GraphQL: Object property",
       "scope": "meta.type.object.graphql variable.graphql",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "GraphQL: Selection set property",
       "scope": "meta.selectionset.graphql variable.graphql",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "GraphQL: Fragment",
@@ -636,7 +636,7 @@
     {
       "name": "Object property",
       "scope": "string.unquoted.js",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Javascript: Language variables",
@@ -863,7 +863,7 @@
     {
       "name": "Typescript: Enum member",
       "scope": "variable.other.enummember.ts",
-      "settings": { "foreground": "#BBD99E" }
+      "settings": { "foreground": "#BBC1CD" }
     },
     {
       "name": "Arrow function. =>",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -358,13 +358,12 @@
       "settings": { "foreground": "#FFBAD1" }
     },
     {
-      "name": "Access to object property",
-      "scope": "variable.other.property",
-      "settings": { "foreground": "#FFBAD1" }
-    },
-    {
       "name": "Object property",
-      "scope": ["meta.object-literal.key", "variable.object.property"],
+      "scope": [
+        "meta.object-literal.key",
+        "variable.object.property",
+        "variable.other.property"
+      ],
       "settings": { "foreground": "#BBD99E" }
     },
     {


### PR DESCRIPTION
### Syntax highlight

#### Changed

- Use darker grey in punctuation marks. They are less relevant than the rest of the code, this change prevents them from standing out
- Use neutral for object property instead of the strings' green
- Use darker color for text

#### Fixed
- Use object property color (neutral) for native objects properties

#### Javascript
- Use same color when defining or accessing an object property