### PR TITLE
feat: fix react syntax highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Syntax highlight
+
+#### Fixed
+
+- Use red for tags. It has better contrast next to attributes and functions
+- Use deep purple for directives to maintain consistency
+
+#### React
+
+- Use orange in the component tag when the language mode is Javascript
+- Use white in the tag's inner text when the language mode is Javascript
+- Use default color (neutral) for punctuation to maintain consistency
+
 ## [1.8.0] 2021-02-15
 
 ### UI
@@ -24,19 +37,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use darker color for text
 
 #### Fixed
+
 - Use object property color (neutral) for native objects properties
 
 #### Javascript
+
 - Use same color when defining or accessing an object property
 
 ## [1.6.2] 2020-03-11
 
 ### Docs
+
 - Improve the wording at "Different syntax highlighting"
 
 ## [1.6.1] 2020-03-11
 
 ### Docs
+
 - How to fix syntax highlighting problems?
 
 ## [1.6.0] 2019-06-16

--- a/src/colors/syntax/common.colors.ts
+++ b/src/colors/syntax/common.colors.ts
@@ -189,14 +189,6 @@ const commonColors: SyntaxColors = (tokens) => {
       scope: 'entity.name.tag',
       settings: tokens.tag.name
     },
-    {
-      name: 'Tag angle brackets',
-      scope: [
-        'punctuation.definition.tag.begin',
-        'punctuation.definition.tag.end'
-      ],
-      settings: tokens.tag.punctuation
-    },
 
     /**
      * Comments

--- a/src/colors/syntax/html.colors.ts
+++ b/src/colors/syntax/html.colors.ts
@@ -28,8 +28,8 @@ const htmlColors: SyntaxColors = (tokens) => {
      */
     {
       name: 'Component tag',
-      scope: 'entity.name.tag.other.html',
-      settings: tokens.html.component.tag
+      scope: ['entity.name.tag.other.html', 'support.class.component'],
+      settings: tokens.html.component
     },
     {
       name: 'Component directives',

--- a/src/colors/syntax/jsx.colors.ts
+++ b/src/colors/syntax/jsx.colors.ts
@@ -3,16 +3,6 @@ import { SyntaxColors } from '../../types/colors-types';
 const jsxColors: SyntaxColors = (tokens) => {
   return [
     {
-      name: 'JSX: Component tag',
-      scope: [
-        'support.class.component.js.jsx',
-        'support.class.component.open.jsx',
-        'support.class.component.close.jsx',
-        'support.class.component.tsx'
-      ],
-      settings: tokens.html.component.tag
-    },
-    {
       name: 'JSX: Attribute',
       scope: [
         'entity.other.attribute-name.js.jsx',

--- a/src/colors/syntax/jsx.colors.ts
+++ b/src/colors/syntax/jsx.colors.ts
@@ -4,10 +4,7 @@ const jsxColors: SyntaxColors = (tokens) => {
   return [
     {
       name: 'JSX: Attribute',
-      scope: [
-        'entity.other.attribute-name.js.jsx',
-        'entity.other.attribute-name.jsx'
-      ],
+      scope: 'entity.other.attribute-name',
       // Pink is used in variables and method arguments
       settings: tokens.tag.attribute
     },

--- a/src/colors/syntax/jsx.colors.ts
+++ b/src/colors/syntax/jsx.colors.ts
@@ -19,7 +19,7 @@ const jsxColors: SyntaxColors = (tokens) => {
     },
     {
       name: 'JSX: Text',
-      scope: ['meta.jsx.children.js.jsx', 'JSXNested', 'meta.jsx.children.tsx'],
+      scope: ['meta.jsx.children.js', 'JSXNested', 'meta.jsx.children.tsx'],
       settings: tokens.text
     }
   ];

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -270,9 +270,7 @@ export const html: Html = {
     value: tag.value
   },
   component: {
-    tag: {
-      foreground: orange[4]
-    }
+   foreground: orange[4]
   },
   directive: {
     foreground: red[4]

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -247,9 +247,6 @@ export const tag: Tag = {
   },
   value: {
     foreground: green[4]
-  },
-  punctuation: {
-    foreground: cyan[5]
   }
 };
 

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -240,7 +240,7 @@ export const config: Config = {
  */
 export const tag: Tag = {
   name: {
-    foreground: cyan[4]
+    foreground: red[4]
   },
   attribute: {
     foreground: blue[4]

--- a/src/themes/universe/syntax-colors.ts
+++ b/src/themes/universe/syntax-colors.ts
@@ -270,7 +270,7 @@ export const html: Html = {
    foreground: orange[4]
   },
   directive: {
-    foreground: red[4]
+    foreground: deepPurple[4]
   }
 };
 

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -73,7 +73,6 @@ export interface Tag {
   name: Settings; // entity.name.tag
   attribute: Settings; // entity.other.attribute-name
   value: Settings;
-  punctuation: Settings;
 }
 
 // Markup

--- a/src/types/tokens-types.ts
+++ b/src/types/tokens-types.ts
@@ -150,9 +150,7 @@ export interface Html {
     attribute: Settings;
     value: Settings;
   };
-  component: {
-    tag: Settings;
-  };
+  component: Settings;
   directive: Settings;
 }
 

--- a/theme/universe.gray.italic.json
+++ b/theme/universe.gray.italic.json
@@ -626,7 +626,7 @@
     },
     {
       "name": "Component tag",
-      "scope": "entity.name.tag.other.html",
+      "scope": ["entity.name.tag.other.html", "support.class.component"],
       "settings": { "foreground": "#F2B09A" }
     },
     {
@@ -687,16 +687,6 @@
       "name": "Property name",
       "scope": "support.type.property-name.json",
       "settings": { "foreground": "#C1A2FF" }
-    },
-    {
-      "name": "JSX: Component tag",
-      "scope": [
-        "support.class.component.js.jsx",
-        "support.class.component.open.jsx",
-        "support.class.component.close.jsx",
-        "support.class.component.tsx"
-      ],
-      "settings": { "foreground": "#F2B09A" }
     },
     {
       "name": "JSX: Attribute",

--- a/theme/universe.gray.italic.json
+++ b/theme/universe.gray.italic.json
@@ -461,7 +461,7 @@
     {
       "name": "Tag",
       "scope": "entity.name.tag",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Comment",
@@ -501,7 +501,7 @@
     {
       "name": "Tag",
       "scope": ["entity.name.tag.css", "meta.selector.css"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "ID",
@@ -599,7 +599,7 @@
     {
       "name": "HTML: Tag",
       "scope": "entity.name.tag.html",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "HTML: Attribute",
@@ -761,12 +761,12 @@
     {
       "name": "Constant",
       "scope": "constant",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Tag",
       "scope": ["meta.tag.sgml.doctype.html", "entity.name.tag.pug"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Attribute",
@@ -889,7 +889,7 @@
     {
       "name": "Property name",
       "scope": "entity.name.tag.yaml",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "YAML: Constant",

--- a/theme/universe.gray.italic.json
+++ b/theme/universe.gray.italic.json
@@ -682,10 +682,7 @@
     },
     {
       "name": "JSX: Attribute",
-      "scope": [
-        "entity.other.attribute-name.js.jsx",
-        "entity.other.attribute-name.jsx"
-      ],
+      "scope": "entity.other.attribute-name",
       "settings": { "foreground": "#9AC6F2" }
     },
     {

--- a/theme/universe.gray.italic.json
+++ b/theme/universe.gray.italic.json
@@ -703,11 +703,7 @@
     },
     {
       "name": "JSX: Text",
-      "scope": [
-        "meta.jsx.children.js.jsx",
-        "JSXNested",
-        "meta.jsx.children.tsx"
-      ],
+      "scope": ["meta.jsx.children.js", "JSXNested", "meta.jsx.children.tsx"],
       "settings": { "foreground": "#D6D9E0" }
     },
     {

--- a/theme/universe.gray.italic.json
+++ b/theme/universe.gray.italic.json
@@ -464,14 +464,6 @@
       "settings": { "foreground": "#92D8E6" }
     },
     {
-      "name": "Tag angle brackets",
-      "scope": [
-        "punctuation.definition.tag.begin",
-        "punctuation.definition.tag.end"
-      ],
-      "settings": { "foreground": "#6EB4C2" }
-    },
-    {
       "name": "Comment",
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": { "foreground": "#758096", "fontStyle": "italic" }

--- a/theme/universe.gray.italic.json
+++ b/theme/universe.gray.italic.json
@@ -624,7 +624,7 @@
     {
       "name": "Component directives",
       "scope": "meta.attribute.unrecognized",
-      "settings": { "foreground": "#FFA2A2", "fontStyle": "italic" }
+      "settings": { "foreground": "#C1A2FF", "fontStyle": "italic" }
     },
     {
       "name": "Object property",
@@ -866,7 +866,7 @@
     {
       "name": "Vue directive",
       "scope": "meta.directive.vue entity.other.attribute-name.html",
-      "settings": { "foreground": "#FFA2A2", "fontStyle": "italic" }
+      "settings": { "foreground": "#C1A2FF", "fontStyle": "italic" }
     },
     {
       "name": "YAML: Document",

--- a/theme/universe.gray.json
+++ b/theme/universe.gray.json
@@ -626,7 +626,7 @@
     },
     {
       "name": "Component tag",
-      "scope": "entity.name.tag.other.html",
+      "scope": ["entity.name.tag.other.html", "support.class.component"],
       "settings": { "foreground": "#F2B09A" }
     },
     {
@@ -687,16 +687,6 @@
       "name": "Property name",
       "scope": "support.type.property-name.json",
       "settings": { "foreground": "#C1A2FF" }
-    },
-    {
-      "name": "JSX: Component tag",
-      "scope": [
-        "support.class.component.js.jsx",
-        "support.class.component.open.jsx",
-        "support.class.component.close.jsx",
-        "support.class.component.tsx"
-      ],
-      "settings": { "foreground": "#F2B09A" }
     },
     {
       "name": "JSX: Attribute",

--- a/theme/universe.gray.json
+++ b/theme/universe.gray.json
@@ -461,7 +461,7 @@
     {
       "name": "Tag",
       "scope": "entity.name.tag",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Comment",
@@ -501,7 +501,7 @@
     {
       "name": "Tag",
       "scope": ["entity.name.tag.css", "meta.selector.css"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "ID",
@@ -599,7 +599,7 @@
     {
       "name": "HTML: Tag",
       "scope": "entity.name.tag.html",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "HTML: Attribute",
@@ -761,12 +761,12 @@
     {
       "name": "Constant",
       "scope": "constant",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Tag",
       "scope": ["meta.tag.sgml.doctype.html", "entity.name.tag.pug"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Attribute",
@@ -889,7 +889,7 @@
     {
       "name": "Property name",
       "scope": "entity.name.tag.yaml",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "YAML: Constant",

--- a/theme/universe.gray.json
+++ b/theme/universe.gray.json
@@ -464,14 +464,6 @@
       "settings": { "foreground": "#92D8E6" }
     },
     {
-      "name": "Tag angle brackets",
-      "scope": [
-        "punctuation.definition.tag.begin",
-        "punctuation.definition.tag.end"
-      ],
-      "settings": { "foreground": "#6EB4C2" }
-    },
-    {
       "name": "Comment",
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": { "foreground": "#758096" }

--- a/theme/universe.gray.json
+++ b/theme/universe.gray.json
@@ -682,10 +682,7 @@
     },
     {
       "name": "JSX: Attribute",
-      "scope": [
-        "entity.other.attribute-name.js.jsx",
-        "entity.other.attribute-name.jsx"
-      ],
+      "scope": "entity.other.attribute-name",
       "settings": { "foreground": "#9AC6F2" }
     },
     {

--- a/theme/universe.gray.json
+++ b/theme/universe.gray.json
@@ -703,11 +703,7 @@
     },
     {
       "name": "JSX: Text",
-      "scope": [
-        "meta.jsx.children.js.jsx",
-        "JSXNested",
-        "meta.jsx.children.tsx"
-      ],
+      "scope": ["meta.jsx.children.js", "JSXNested", "meta.jsx.children.tsx"],
       "settings": { "foreground": "#D6D9E0" }
     },
     {

--- a/theme/universe.gray.json
+++ b/theme/universe.gray.json
@@ -624,7 +624,7 @@
     {
       "name": "Component directives",
       "scope": "meta.attribute.unrecognized",
-      "settings": { "foreground": "#FFA2A2" }
+      "settings": { "foreground": "#C1A2FF" }
     },
     {
       "name": "Object property",
@@ -866,7 +866,7 @@
     {
       "name": "Vue directive",
       "scope": "meta.directive.vue entity.other.attribute-name.html",
-      "settings": { "foreground": "#FFA2A2" }
+      "settings": { "foreground": "#C1A2FF" }
     },
     {
       "name": "YAML: Document",

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -626,7 +626,7 @@
     },
     {
       "name": "Component tag",
-      "scope": "entity.name.tag.other.html",
+      "scope": ["entity.name.tag.other.html", "support.class.component"],
       "settings": { "foreground": "#F2B09A" }
     },
     {
@@ -687,16 +687,6 @@
       "name": "Property name",
       "scope": "support.type.property-name.json",
       "settings": { "foreground": "#C1A2FF" }
-    },
-    {
-      "name": "JSX: Component tag",
-      "scope": [
-        "support.class.component.js.jsx",
-        "support.class.component.open.jsx",
-        "support.class.component.close.jsx",
-        "support.class.component.tsx"
-      ],
-      "settings": { "foreground": "#F2B09A" }
     },
     {
       "name": "JSX: Attribute",

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -461,7 +461,7 @@
     {
       "name": "Tag",
       "scope": "entity.name.tag",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Comment",
@@ -501,7 +501,7 @@
     {
       "name": "Tag",
       "scope": ["entity.name.tag.css", "meta.selector.css"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "ID",
@@ -599,7 +599,7 @@
     {
       "name": "HTML: Tag",
       "scope": "entity.name.tag.html",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "HTML: Attribute",
@@ -761,12 +761,12 @@
     {
       "name": "Constant",
       "scope": "constant",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Tag",
       "scope": ["meta.tag.sgml.doctype.html", "entity.name.tag.pug"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Attribute",
@@ -889,7 +889,7 @@
     {
       "name": "Property name",
       "scope": "entity.name.tag.yaml",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "YAML: Constant",

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -682,10 +682,7 @@
     },
     {
       "name": "JSX: Attribute",
-      "scope": [
-        "entity.other.attribute-name.js.jsx",
-        "entity.other.attribute-name.jsx"
-      ],
+      "scope": "entity.other.attribute-name",
       "settings": { "foreground": "#9AC6F2" }
     },
     {

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -703,11 +703,7 @@
     },
     {
       "name": "JSX: Text",
-      "scope": [
-        "meta.jsx.children.js.jsx",
-        "JSXNested",
-        "meta.jsx.children.tsx"
-      ],
+      "scope": ["meta.jsx.children.js", "JSXNested", "meta.jsx.children.tsx"],
       "settings": { "foreground": "#D6D9E0" }
     },
     {

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -464,14 +464,6 @@
       "settings": { "foreground": "#92D8E6" }
     },
     {
-      "name": "Tag angle brackets",
-      "scope": [
-        "punctuation.definition.tag.begin",
-        "punctuation.definition.tag.end"
-      ],
-      "settings": { "foreground": "#6EB4C2" }
-    },
-    {
       "name": "Comment",
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": { "foreground": "#758096", "fontStyle": "italic" }

--- a/theme/universe.italic.json
+++ b/theme/universe.italic.json
@@ -624,7 +624,7 @@
     {
       "name": "Component directives",
       "scope": "meta.attribute.unrecognized",
-      "settings": { "foreground": "#FFA2A2", "fontStyle": "italic" }
+      "settings": { "foreground": "#C1A2FF", "fontStyle": "italic" }
     },
     {
       "name": "Object property",
@@ -866,7 +866,7 @@
     {
       "name": "Vue directive",
       "scope": "meta.directive.vue entity.other.attribute-name.html",
-      "settings": { "foreground": "#FFA2A2", "fontStyle": "italic" }
+      "settings": { "foreground": "#C1A2FF", "fontStyle": "italic" }
     },
     {
       "name": "YAML: Document",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -626,7 +626,7 @@
     },
     {
       "name": "Component tag",
-      "scope": "entity.name.tag.other.html",
+      "scope": ["entity.name.tag.other.html", "support.class.component"],
       "settings": { "foreground": "#F2B09A" }
     },
     {
@@ -687,16 +687,6 @@
       "name": "Property name",
       "scope": "support.type.property-name.json",
       "settings": { "foreground": "#C1A2FF" }
-    },
-    {
-      "name": "JSX: Component tag",
-      "scope": [
-        "support.class.component.js.jsx",
-        "support.class.component.open.jsx",
-        "support.class.component.close.jsx",
-        "support.class.component.tsx"
-      ],
-      "settings": { "foreground": "#F2B09A" }
     },
     {
       "name": "JSX: Attribute",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -461,7 +461,7 @@
     {
       "name": "Tag",
       "scope": "entity.name.tag",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Comment",
@@ -501,7 +501,7 @@
     {
       "name": "Tag",
       "scope": ["entity.name.tag.css", "meta.selector.css"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "ID",
@@ -599,7 +599,7 @@
     {
       "name": "HTML: Tag",
       "scope": "entity.name.tag.html",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "HTML: Attribute",
@@ -761,12 +761,12 @@
     {
       "name": "Constant",
       "scope": "constant",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Tag",
       "scope": ["meta.tag.sgml.doctype.html", "entity.name.tag.pug"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Attribute",
@@ -889,7 +889,7 @@
     {
       "name": "Property name",
       "scope": "entity.name.tag.yaml",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "YAML: Constant",

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -464,14 +464,6 @@
       "settings": { "foreground": "#92D8E6" }
     },
     {
-      "name": "Tag angle brackets",
-      "scope": [
-        "punctuation.definition.tag.begin",
-        "punctuation.definition.tag.end"
-      ],
-      "settings": { "foreground": "#6EB4C2" }
-    },
-    {
       "name": "Comment",
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": { "foreground": "#758096" }

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -682,10 +682,7 @@
     },
     {
       "name": "JSX: Attribute",
-      "scope": [
-        "entity.other.attribute-name.js.jsx",
-        "entity.other.attribute-name.jsx"
-      ],
+      "scope": "entity.other.attribute-name",
       "settings": { "foreground": "#9AC6F2" }
     },
     {

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -703,11 +703,7 @@
     },
     {
       "name": "JSX: Text",
-      "scope": [
-        "meta.jsx.children.js.jsx",
-        "JSXNested",
-        "meta.jsx.children.tsx"
-      ],
+      "scope": ["meta.jsx.children.js", "JSXNested", "meta.jsx.children.tsx"],
       "settings": { "foreground": "#D6D9E0" }
     },
     {

--- a/theme/universe.json
+++ b/theme/universe.json
@@ -624,7 +624,7 @@
     {
       "name": "Component directives",
       "scope": "meta.attribute.unrecognized",
-      "settings": { "foreground": "#FFA2A2" }
+      "settings": { "foreground": "#C1A2FF" }
     },
     {
       "name": "Object property",
@@ -866,7 +866,7 @@
     {
       "name": "Vue directive",
       "scope": "meta.directive.vue entity.other.attribute-name.html",
-      "settings": { "foreground": "#FFA2A2" }
+      "settings": { "foreground": "#C1A2FF" }
     },
     {
       "name": "YAML: Document",

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -626,7 +626,7 @@
     },
     {
       "name": "Component tag",
-      "scope": "entity.name.tag.other.html",
+      "scope": ["entity.name.tag.other.html", "support.class.component"],
       "settings": { "foreground": "#F2B09A" }
     },
     {
@@ -687,16 +687,6 @@
       "name": "Property name",
       "scope": "support.type.property-name.json",
       "settings": { "foreground": "#C1A2FF" }
-    },
-    {
-      "name": "JSX: Component tag",
-      "scope": [
-        "support.class.component.js.jsx",
-        "support.class.component.open.jsx",
-        "support.class.component.close.jsx",
-        "support.class.component.tsx"
-      ],
-      "settings": { "foreground": "#F2B09A" }
     },
     {
       "name": "JSX: Attribute",

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -461,7 +461,7 @@
     {
       "name": "Tag",
       "scope": "entity.name.tag",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Comment",
@@ -501,7 +501,7 @@
     {
       "name": "Tag",
       "scope": ["entity.name.tag.css", "meta.selector.css"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "ID",
@@ -599,7 +599,7 @@
     {
       "name": "HTML: Tag",
       "scope": "entity.name.tag.html",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "HTML: Attribute",
@@ -761,12 +761,12 @@
     {
       "name": "Constant",
       "scope": "constant",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Tag",
       "scope": ["meta.tag.sgml.doctype.html", "entity.name.tag.pug"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Attribute",
@@ -889,7 +889,7 @@
     {
       "name": "Property name",
       "scope": "entity.name.tag.yaml",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "YAML: Constant",

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -682,10 +682,7 @@
     },
     {
       "name": "JSX: Attribute",
-      "scope": [
-        "entity.other.attribute-name.js.jsx",
-        "entity.other.attribute-name.jsx"
-      ],
+      "scope": "entity.other.attribute-name",
       "settings": { "foreground": "#9AC6F2" }
     },
     {

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -703,11 +703,7 @@
     },
     {
       "name": "JSX: Text",
-      "scope": [
-        "meta.jsx.children.js.jsx",
-        "JSXNested",
-        "meta.jsx.children.tsx"
-      ],
+      "scope": ["meta.jsx.children.js", "JSXNested", "meta.jsx.children.tsx"],
       "settings": { "foreground": "#D6D9E0" }
     },
     {

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -464,14 +464,6 @@
       "settings": { "foreground": "#92D8E6" }
     },
     {
-      "name": "Tag angle brackets",
-      "scope": [
-        "punctuation.definition.tag.begin",
-        "punctuation.definition.tag.end"
-      ],
-      "settings": { "foreground": "#6EB4C2" }
-    },
-    {
       "name": "Comment",
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": { "foreground": "#758096", "fontStyle": "italic" }

--- a/theme/universe.purple.italic.json
+++ b/theme/universe.purple.italic.json
@@ -624,7 +624,7 @@
     {
       "name": "Component directives",
       "scope": "meta.attribute.unrecognized",
-      "settings": { "foreground": "#FFA2A2", "fontStyle": "italic" }
+      "settings": { "foreground": "#C1A2FF", "fontStyle": "italic" }
     },
     {
       "name": "Object property",
@@ -866,7 +866,7 @@
     {
       "name": "Vue directive",
       "scope": "meta.directive.vue entity.other.attribute-name.html",
-      "settings": { "foreground": "#FFA2A2", "fontStyle": "italic" }
+      "settings": { "foreground": "#C1A2FF", "fontStyle": "italic" }
     },
     {
       "name": "YAML: Document",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -626,7 +626,7 @@
     },
     {
       "name": "Component tag",
-      "scope": "entity.name.tag.other.html",
+      "scope": ["entity.name.tag.other.html", "support.class.component"],
       "settings": { "foreground": "#F2B09A" }
     },
     {
@@ -687,16 +687,6 @@
       "name": "Property name",
       "scope": "support.type.property-name.json",
       "settings": { "foreground": "#C1A2FF" }
-    },
-    {
-      "name": "JSX: Component tag",
-      "scope": [
-        "support.class.component.js.jsx",
-        "support.class.component.open.jsx",
-        "support.class.component.close.jsx",
-        "support.class.component.tsx"
-      ],
-      "settings": { "foreground": "#F2B09A" }
     },
     {
       "name": "JSX: Attribute",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -461,7 +461,7 @@
     {
       "name": "Tag",
       "scope": "entity.name.tag",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Comment",
@@ -501,7 +501,7 @@
     {
       "name": "Tag",
       "scope": ["entity.name.tag.css", "meta.selector.css"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "ID",
@@ -599,7 +599,7 @@
     {
       "name": "HTML: Tag",
       "scope": "entity.name.tag.html",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "HTML: Attribute",
@@ -761,12 +761,12 @@
     {
       "name": "Constant",
       "scope": "constant",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Tag",
       "scope": ["meta.tag.sgml.doctype.html", "entity.name.tag.pug"],
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "Pug: Attribute",
@@ -889,7 +889,7 @@
     {
       "name": "Property name",
       "scope": "entity.name.tag.yaml",
-      "settings": { "foreground": "#92D8E6" }
+      "settings": { "foreground": "#FFA2A2" }
     },
     {
       "name": "YAML: Constant",

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -464,14 +464,6 @@
       "settings": { "foreground": "#92D8E6" }
     },
     {
-      "name": "Tag angle brackets",
-      "scope": [
-        "punctuation.definition.tag.begin",
-        "punctuation.definition.tag.end"
-      ],
-      "settings": { "foreground": "#6EB4C2" }
-    },
-    {
       "name": "Comment",
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": { "foreground": "#758096" }

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -682,10 +682,7 @@
     },
     {
       "name": "JSX: Attribute",
-      "scope": [
-        "entity.other.attribute-name.js.jsx",
-        "entity.other.attribute-name.jsx"
-      ],
+      "scope": "entity.other.attribute-name",
       "settings": { "foreground": "#9AC6F2" }
     },
     {

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -703,11 +703,7 @@
     },
     {
       "name": "JSX: Text",
-      "scope": [
-        "meta.jsx.children.js.jsx",
-        "JSXNested",
-        "meta.jsx.children.tsx"
-      ],
+      "scope": ["meta.jsx.children.js", "JSXNested", "meta.jsx.children.tsx"],
       "settings": { "foreground": "#D6D9E0" }
     },
     {

--- a/theme/universe.purple.json
+++ b/theme/universe.purple.json
@@ -624,7 +624,7 @@
     {
       "name": "Component directives",
       "scope": "meta.attribute.unrecognized",
-      "settings": { "foreground": "#FFA2A2" }
+      "settings": { "foreground": "#C1A2FF" }
     },
     {
       "name": "Object property",
@@ -866,7 +866,7 @@
     {
       "name": "Vue directive",
       "scope": "meta.directive.vue entity.other.attribute-name.html",
-      "settings": { "foreground": "#FFA2A2" }
+      "settings": { "foreground": "#C1A2FF" }
     },
     {
       "name": "YAML: Document",


### PR DESCRIPTION
### Syntax highlight

#### Fixed
- Use red for tags. It has better contrast next to attributes and functions
- Use deep purple for directives to maintain consistency

#### React
- Use orange in the component tag when the language mode is Javascript
- Use white in the tag's inner text when the language mode is Javascript
- Use default color (neutral) for punctuation to maintain consistency
